### PR TITLE
Removing multiple spaces in stop names

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -53,8 +53,8 @@ const Map<String, String> fallback_code_to_name = {
 final _whitespacePattern = RegExp(r'\s+');
 
 String normalizeStopName(String rawStopName) {
-  // Collapse any sequence of whitespace to a single space and trim edges.
-  return rawStopName.replaceAll(_whitespacePattern, ' ').trim();
+  // Remove random characters (add them to list if needed), collapse whitespace to a single space, and trim edges.
+  return rawStopName.replaceAll('%', '').replaceAll(_whitespacePattern, ' ').trim();
 }
 
 String getPrettyRouteName(String code) {

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -50,6 +50,13 @@ const Map<String, String> fallback_code_to_name = {
   'NES': 'North-East Shuttle',
 };
 
+final _whitespacePattern = RegExp(r'\s+');
+
+String normalizeStopName(String rawStopName) {
+  // Collapse any sequence of whitespace to a single space and trim edges.
+  return rawStopName.replaceAll(_whitespacePattern, ' ').trim();
+}
+
 String getPrettyRouteName(String code) {
   for (Map<String, String> route in globalAvailableRoutes) {
     if (route['id'] == code) {

--- a/lib/models/bus_stop.dart
+++ b/lib/models/bus_stop.dart
@@ -1,4 +1,5 @@
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import '../constants.dart';
 
 class BusStop {
   final String id;
@@ -13,7 +14,7 @@ class BusStop {
   factory BusStop.fromJson(Map<String, dynamic> json, String routeId, double rotation, bool isRide) {
     return BusStop(
       id: json['stpid'] ?? '',
-      name: json['stpnm'] ?? '',
+      name: normalizeStopName(json['stpnm'] ?? ''),
       location: LatLng(json['lat']?.toDouble() ?? 0, json['lon']?.toDouble() ?? 0),
       routeId: routeId,
       rotation: rotation, 
@@ -33,7 +34,7 @@ class BusStopWithPrediction {
   factory BusStopWithPrediction.fromJson(Map<String, dynamic> json) {
     return BusStopWithPrediction(
       id: json['stpid'] ?? '',
-      name: json['stpnm'] ?? '',
+      name: normalizeStopName(json['stpnm'] ?? ''),
       prediction: json['prdctdn'] as String,
       busRouteCode: json['rt'] ?? ''
     );
@@ -52,7 +53,7 @@ class BusWithPrediction {
   factory BusWithPrediction.fromJson(Map<String, dynamic> json) {
     return BusWithPrediction(
       id: json['rt'] ?? '',
-      destination: json['des'] ?? '',
+      destination: normalizeStopName(json['des'] ?? ''),
       prediction: json['prdctdn'] as String,
       direction: json['rtdir'] as String,
       vehicleId: json['vid'] ?? 'none'

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -329,7 +329,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         final stopList = jsonDecode(response.body) as List<dynamic>;
 
         return stopList.map((stop) {
-          final name = stop['name'] as String;
+          final name = normalizeStopName(stop['name'] as String);
           final aliases = [
             name.split(' ').map((w) => w.isNotEmpty ? w[0] : '').join(),
           ];

--- a/lib/widgets/search_sheet_main.dart
+++ b/lib/widgets/search_sheet_main.dart
@@ -85,7 +85,7 @@ class LocationSearchBar extends HookWidget {
             final stopList = jsonDecode(response.body) as List<dynamic>;
             
             return stopList.map((stop) {
-              final name = stop['name'] as String;
+              final name = normalizeStopName(stop['name'] as String);
               final aliases = [
                 name.split(' ').map((w) => w.isNotEmpty ? w[0] : '').join(),
               ];


### PR DESCRIPTION
Removed extra spaces in stop names with a new function in constants.dart

Function is called anywhere json['stpnm'], stop['name'], or json['des'] is used