### PR TITLE
Persistent Favorited Stops

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -104,6 +104,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   Set<Polyline> _displayedPolylines = {};
   Set<Marker> _displayedStopMarkers = {};
+  Set<Marker> _displayedFavoriteStopMarkers = {};
   Set<Marker> _displayedBusMarkers = {};
   // Journey overlays for search results
   Set<Polyline> _displayedJourneyPolylines = {};
@@ -771,14 +772,16 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
       }
       if (!_routeStopMarkers.containsKey(routeKey)) {
         _routeStopMarkers[routeKey] = r.stops
-            .map(
-              (stop) => Marker(
+            .map((stop) {
+              final isFavorite = _favoriteStops.contains(stop.id);
+
+              final marker = Marker(
                 markerId: MarkerId(
                   'stop_${stop.id}_${Object.hashAll(r.points)}',
                 ),
                 position: stop.location,
                 flat: true,
-                icon: _favoriteStops.contains(stop.id)
+                icon: isFavorite
                     ? (stop.isRide
                           ? _favRideStopIcon ??
                                 BitmapDescriptor.defaultMarkerWithHue(
@@ -812,9 +815,12 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
                 },
                 rotation: stop.rotation,
                 anchor: Offset(0.5, 0.5),
-              ),
-            )
-            .toSet();
+              );
+              
+              // add created stop marker to the favorited markers if it is favorited
+              if (isFavorite) _displayedFavoriteStopMarkers.add(marker);
+              return marker;
+            }).toSet();
       }
     }
   }
@@ -853,7 +859,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
     _routeStopMarkers.forEach((routeKey, markers) {
       final updated = markers.map((m) {
         if (m.markerId.value.startsWith('stop_${stpid}_')) {
-          return Marker(
+          final marker = Marker(
             flat: true,
             markerId: m.markerId,
             position: m.position,
@@ -872,6 +878,15 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
             rotation: m.rotation,
             anchor: m.anchor,
           );
+
+          // add or remove the marker from the displayed favorite stops
+          if (!favored) {
+            _displayedFavoriteStopMarkers.remove(m);
+          } else {
+            _displayedFavoriteStopMarkers.add(marker);
+          }
+
+          return marker;
         }
         return m;
       }).toSet();
@@ -1010,6 +1025,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   void _updateAllDisplayedMarkers() {
     _allDisplayedStopMarkers = _displayedStopMarkers
+        .union(_displayedFavoriteStopMarkers)
         .union(_displayedBusMarkers)
         .union(_displayedJourneyMarkers)
         .union(_searchLocationMarker != null ? {_searchLocationMarker!} : {});
@@ -1078,6 +1094,8 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   void _refreshCachedStopMarkers() {
     // Clear cached stop markers so they'll be recreated with the new icons
     _routeStopMarkers.clear();
+    // also clear persistent favorited stop markers to be refreshed in _cacheRouteOverlays(..)
+    _displayedFavoriteStopMarkers.clear();
     // Re-cache all route overlays with the new icons
     _cacheRouteOverlays(
       Provider.of<BusProvider>(context, listen: false).routes,
@@ -2129,6 +2147,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
                                           : {},
                                     )
                                   : _displayedStopMarkers
+                                        .union(_displayedFavoriteStopMarkers)
                                         .union(_displayedJourneyMarkers)
                                         .union(
                                           _searchLocationMarker != null

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1916,6 +1916,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         return StopSheet(
           stopID: stopID,
           stopName: stopName,
+          isFavorite: _favoriteStops.contains(stopID),
           onFavorite: _addFavoriteStop,
           onUnFavorite: _removeFavoriteStop,
           showBusSheet: (busId) {

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -103,8 +103,8 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   static const LatLng _defaultCenter = LatLng(42.276463, -83.7374598);
 
   Set<Polyline> _displayedPolylines = {};
-  Set<Marker> _displayedStopMarkers = {};
-  Set<Marker> _displayedFavoriteStopMarkers = {};
+  Map<String, Marker> _displayedStopMarkers = {}; // maps from stopID to marker
+  Map<String, Marker> _displayedFavoriteStopMarkers = {};
   Set<Marker> _displayedBusMarkers = {};
   // Journey overlays for search results
   Set<Polyline> _displayedJourneyPolylines = {};
@@ -136,7 +136,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   // Memoization caches
   final Map<String, Polyline> _routePolylines = {};
-  final Map<String, Set<Marker>> _routeStopMarkers = {};
+  final Map<String, Map<String, Marker>> _routeStopMarkers = {}; // maps from route to a map of stopID to marker
   // Whether a journey search overlay is currently active (shows only journey path)
   bool _journeyOverlayActive = false;
   // maximum allowed distance (meters) from a stop to a candidate polyline point
@@ -772,57 +772,59 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         );
       }
       if (!_routeStopMarkers.containsKey(routeKey)) {
-        _routeStopMarkers[routeKey] = r.stops
-            .map((stop) {
-              final isFavorite = _favoriteStops.contains(stop.id);
+        _routeStopMarkers[routeKey] = {};
+        for (final stop in r.stops) { // iterate through all stops in this route
+          final isFavorite = _favoriteStops.contains(stop.id);
+          
+          final marker = Marker(
+            markerId: MarkerId(
+              'stop_${stop.id}_${Object.hashAll(r.points)}',
+            ),
+            position: stop.location,
+            flat: true,
+            icon: isFavorite
+                ? (stop.isRide
+                      ? _favRideStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )
+                      : _favStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            ))
+                : (stop.isRide
+                      ? _rideStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )
+                      : _stopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )),
+            consumeTapEvents: true,
+            onTap: () {
+              try {
+                Haptics.vibrate(HapticsType.light);
+              } catch (e) {}
 
-              final marker = Marker(
-                markerId: MarkerId(
-                  'stop_${stop.id}_${Object.hashAll(r.points)}',
-                ),
-                position: stop.location,
-                flat: true,
-                icon: isFavorite
-                    ? (stop.isRide
-                          ? _favRideStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )
-                          : _favStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                ))
-                    : (stop.isRide
-                          ? _rideStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )
-                          : _stopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )),
-                consumeTapEvents: true,
-                onTap: () {
-                  try {
-                    Haptics.vibrate(HapticsType.light);
-                  } catch (e) {}
-
-                  _showStopSheet(
-                    stop.id,
-                    stop.name,
-                    stop.location.latitude,
-                    stop.location.longitude,
-                  );
-                },
-                rotation: stop.rotation,
-                anchor: Offset(0.5, 0.5),
+              _showStopSheet(
+                stop.id,
+                stop.name,
+                stop.location.latitude,
+                stop.location.longitude,
               );
-              
-              // add created stop marker to the favorited markers if it is favorited
-              if (isFavorite) _displayedFavoriteStopMarkers.add(marker);
-              _stopIsRide[stop.id] = stop.isRide;
-              return marker;
-            }).toSet();
+            },
+            rotation: stop.rotation,
+            anchor: Offset(0.5, 0.5),
+          );
+          _routeStopMarkers[routeKey]?[stop.id] = marker;
+
+          // gets first marker of this stop and adds it to the favorited stop markers 
+          if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
+            _displayedFavoriteStopMarkers[stop.id] = marker;
+          }
+          _stopIsRide[stop.id] = stop.isRide;
+        }
       }
     }
   }
@@ -860,62 +862,71 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
     // Update all routeStopMarkers entries that match this stop id
     final isRide = _stopIsRide[stpid] ?? false;
     _routeStopMarkers.forEach((routeKey, markers) {
-      final updated = markers.map((m) {
-        if (m.markerId.value.startsWith('stop_${stpid}_')) {
-          final marker = Marker(
-            flat: true,
-            markerId: m.markerId,
-            position: m.position,
-            icon: favored
-                    ? (isRide
-                          ? _favRideStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )
-                          : _favStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                ))
-                    : (isRide
-                          ? _rideStopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )
-                          : _stopIcon ??
-                                BitmapDescriptor.defaultMarkerWithHue(
-                                  BitmapDescriptor.hueAzure,
-                                )),
-            consumeTapEvents: m.consumeTapEvents,
-            onTap: m.onTap,
-            rotation: m.rotation,
-            anchor: m.anchor,
-          );
+      // if marker does not exist in this route, return
+      if (!markers.containsKey(stpid)) return;
 
-          // add or remove the marker from the displayed favorite stops
-          if (!favored) {
-            _displayedFavoriteStopMarkers.remove(m);
-          } else {
-            _displayedFavoriteStopMarkers.add(marker);
-          }
+      final m = markers[stpid]!; // get old marker
+      final newMarker = Marker(
+        flat: true,
+        markerId: m.markerId,
+        position: m.position,
+        icon: favored
+                ? (isRide
+                      ? _favRideStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )
+                      : _favStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            ))
+                : (isRide
+                      ? _rideStopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )
+                      : _stopIcon ??
+                            BitmapDescriptor.defaultMarkerWithHue(
+                              BitmapDescriptor.hueAzure,
+                            )),
+        consumeTapEvents: m.consumeTapEvents,
+        onTap: m.onTap,
+        rotation: m.rotation,
+        anchor: m.anchor,
+      );
 
-          return marker;
-        }
-        return m;
-      }).toSet();
-      _routeStopMarkers[routeKey] = updated;
+      // gets first marker of this stop id and adds it to the favorited stop markers 
+      if (favored && !_displayedFavoriteStopMarkers.containsKey(stpid)) {
+        _displayedFavoriteStopMarkers[stpid] = newMarker;
+      }
+
+      markers[stpid] = newMarker; // set as new marker
     });
+
+    // remove favorite stop marker if not favored
+    if (!favored) {
+      _displayedFavoriteStopMarkers.remove(stpid);
+    }
 
     // If displayed, update displayed markers as well
     setState(() {
       // Rebuild displayed stop markers based on current selected routes
-      final selectedStopMarkers = <Marker>{};
+      final selectedStopMarkers = <String, Marker>{};
       for (final routeId in _selectedRoutes) {
         final routeVariants = _routePolylines.keys.where(
           (key) => key.startsWith('${routeId}_'),
         );
         for (final routeKey in routeVariants) {
           final stops = _routeStopMarkers[routeKey];
-          if (stops != null) selectedStopMarkers.addAll(stops);
+          if (stops == null) continue;
+
+          // iterate through and add the stop markers
+          // if they are not already in the selected stop markesr
+          stops.forEach((key, value) {
+            if (!selectedStopMarkers.containsKey(key)) {
+              selectedStopMarkers[key] = value;
+            }
+          });
         }
       }
       _displayedStopMarkers = selectedStopMarkers;
@@ -925,7 +936,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   void _updateDisplayedRoutes() {
     final selectedPolylines = <Polyline>{};
-    final selectedStopMarkers = <Marker>{};
+    final selectedStopMarkers = <String, Marker>{};
 
     for (final routeId in _selectedRoutes) {
       // Find all variants of this route
@@ -937,9 +948,13 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         final polyline = _routePolylines[routeKey];
         if (polyline != null) selectedPolylines.add(polyline);
         final stops = _routeStopMarkers[routeKey];
-        if (stops != null) {
-          selectedStopMarkers.addAll(stops);
-        }
+        if (stops == null) continue;
+          
+        stops.forEach((key, value) {
+          if (!selectedStopMarkers.containsKey(key)) {
+            selectedStopMarkers[key] = value;
+          }
+        });
       }
     }
 
@@ -1036,8 +1051,8 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   }
 
   void _updateAllDisplayedMarkers() {
-    _allDisplayedStopMarkers = _displayedStopMarkers
-        .union(_displayedFavoriteStopMarkers)
+    _allDisplayedStopMarkers = _displayedStopMarkers.values.toSet()
+        .union(_displayedFavoriteStopMarkers.values.toSet())
         .union(_displayedBusMarkers)
         .union(_displayedJourneyMarkers)
         .union(_searchLocationMarker != null ? {_searchLocationMarker!} : {});
@@ -2158,8 +2173,8 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
                                           ? {_searchLocationMarker!}
                                           : {},
                                     )
-                                  : _displayedStopMarkers
-                                        .union(_displayedFavoriteStopMarkers)
+                                  : _displayedStopMarkers.values.toSet()
+                                        .union(_displayedFavoriteStopMarkers.values.toSet())
                                         .union(_displayedJourneyMarkers)
                                         .union(
                                           _searchLocationMarker != null

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -120,6 +120,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   Marker? _searchLocationMarker;
   final Set<String> _selectedRoutes = <String>{};
   List<Map<String, String>> _availableRoutes = [];
+  Map<String, bool> _stopIsRide = {};
 
   // Custom marker icons
   BitmapDescriptor? _busIcon;
@@ -819,6 +820,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
               
               // add created stop marker to the favorited markers if it is favorited
               if (isFavorite) _displayedFavoriteStopMarkers.add(marker);
+              _stopIsRide[stop.id] = stop.isRide;
               return marker;
             }).toSet();
       }
@@ -856,6 +858,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   // Update cached markers for a specific stop id to reflect favorite/unfavorite
   void _setStopFavorited(String stpid, bool favored) {
     // Update all routeStopMarkers entries that match this stop id
+    final isRide = _stopIsRide[stpid] ?? false;
     _routeStopMarkers.forEach((routeKey, markers) {
       final updated = markers.map((m) {
         if (m.markerId.value.startsWith('stop_${stpid}_')) {
@@ -864,15 +867,24 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
             markerId: m.markerId,
             position: m.position,
             icon: favored
-                ? (_favStopIcon ??
-                      _stopIcon ??
-                      BitmapDescriptor.defaultMarkerWithHue(
-                        BitmapDescriptor.hueAzure,
-                      ))
-                : (_stopIcon ??
-                      BitmapDescriptor.defaultMarkerWithHue(
-                        BitmapDescriptor.hueAzure,
-                      )),
+                    ? (isRide
+                          ? _favRideStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )
+                          : _favStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                ))
+                    : (isRide
+                          ? _rideStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )
+                          : _stopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )),
             consumeTapEvents: m.consumeTapEvents,
             onTap: m.onTap,
             rotation: m.rotation,

--- a/lib/services/bus_info_service.dart
+++ b/lib/services/bus_info_service.dart
@@ -32,12 +32,7 @@ Future<List<BusStopWithPrediction>> fetchNextBusStops(String busID) async {
 }
 
 // for bus stops
-Future<(List<BusWithPrediction>, bool)> fetchStopData(String stopID) async {
-
-  final prefs = await SharedPreferences.getInstance();
-  final list = prefs.getStringList('favorite_stops') ?? <String>[];
-  bool toReturn = list.contains(stopID);
-
+Future<List<BusWithPrediction>> fetchStopData(String stopID) async {
   Uri url;
 
   if (int.tryParse(stopID) != null) {
@@ -53,7 +48,7 @@ Future<(List<BusWithPrediction>, bool)> fetchStopData(String stopID) async {
   if (response.statusCode == 200) {
     final Map<String, dynamic> data = json.decode(response.body);
     final List<dynamic> predictions = data['bustime-response']['prd'];
-    return (predictions.map((json) => BusWithPrediction.fromJson(json)).toList(), toReturn);
+    return predictions.map((json) => BusWithPrediction.fromJson(json)).toList();
   } else {
     throw Exception('Failed to load bus stops');
   }

--- a/lib/widgets/bus_sheet.dart
+++ b/lib/widgets/bus_sheet.dart
@@ -50,8 +50,8 @@ class _BusSheetState extends State<BusSheet> {
 
         showMaizebusOKDialog(
           contextIn: context,
-          title: const Text("Uh Oh!"),
-          content: const Text("Unable to fetch bus data. Please check your internet connection and try again."),
+          title: "Uh Oh!",
+          content: "Unable to fetch bus data. Please check your internet connection and try again.",
         );
       }); 
     } else { 

--- a/lib/widgets/mini_stop_sheet.dart
+++ b/lib/widgets/mini_stop_sheet.dart
@@ -40,7 +40,7 @@ class MiniStopSheet extends StatefulWidget {
 }
 
 class _MiniStopSheetState extends State<MiniStopSheet> {
-  late Future<(List<BusWithPrediction>, bool)> loadedStopData;
+  late Future<List<BusWithPrediction>> loadedStopData;
 
   @override
   void initState() {
@@ -64,7 +64,7 @@ class _MiniStopSheetState extends State<MiniStopSheet> {
           List<BusWithPrediction> arrivingBuses = [];
           
           if (snapshot.hasData){
-            arrivingBuses = snapshot.data!.$1;
+            arrivingBuses = snapshot.data!;
           }
           
           if (snapshot.hasData) {

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -16,6 +16,7 @@ import 'upcoming_stops_widget.dart';
 class StopSheet extends StatefulWidget {
   final String stopID;
   final String stopName;
+  final bool isFavorite;
   final Future<void> Function(String, String) onFavorite;
   final Future<void> Function(String, String) onUnFavorite;
   final void Function() onGetDirections;
@@ -26,6 +27,7 @@ class StopSheet extends StatefulWidget {
     Key? key,
     required this.stopID,
     required this.stopName,
+    required this.isFavorite,
     required this.onFavorite,
     required this.onUnFavorite,
     required this.onGetDirections,
@@ -216,8 +218,8 @@ class ExpandableStopWidget extends StatefulWidget {
 }
 
 class _StopSheetState extends State<StopSheet> {
-  late Future<(List<BusWithPrediction>, bool)> loadedStopData;
-  bool? _isFavorited;
+  late Future<List<BusWithPrediction>> loadedStopData;
+  late bool _isFavorite;
 
   // for select bus stops with images
   late bool imageBusStop;
@@ -227,6 +229,7 @@ class _StopSheetState extends State<StopSheet> {
   void initState() {
     super.initState();
     loadedStopData = fetchStopData(widget.stopID);
+    _isFavorite = widget.isFavorite;
     imageBusStop =
         (widget.stopID == "C250") ||
         (widget.stopID == "N406") ||
@@ -284,13 +287,10 @@ class _StopSheetState extends State<StopSheet> {
             List<BusWithPrediction> arrivingBuses = [];
 
             if (snapshot.hasData) {
-              arrivingBuses = snapshot.data!.$1;
+              arrivingBuses = snapshot.data!;
               arrivingBuses.sort(
                 (lhs, rhs) => (int.tryParse(lhs.prediction) ?? 0).compareTo(int.tryParse(rhs.prediction) ?? 0)
               );
-              if (_isFavorited == null) {
-                _isFavorited = snapshot.data!.$2;
-              }
             }
 
             double initialSize = 0.9;
@@ -675,11 +675,8 @@ class _StopSheetState extends State<StopSheet> {
                                             
                                       ElevatedButton(
                                         onPressed: () {
-                                          // Read the current state
-                                          final bool currentStatus = _isFavorited ?? false;
-                                            
                                           // Call the appropriate function
-                                          if (currentStatus){
+                                          if (_isFavorite){
                                             widget.onUnFavorite(widget.stopID, widget.stopName);
                                           } else {
                                             widget.onFavorite(widget.stopID, widget.stopName);
@@ -687,7 +684,7 @@ class _StopSheetState extends State<StopSheet> {
                                             
                                           // Update the UI immediately
                                           setState(() {
-                                            _isFavorited = !currentStatus;
+                                            _isFavorite = !_isFavorite;
                                           });
                                         },
                                         style: ElevatedButton.styleFrom(
@@ -701,8 +698,8 @@ class _StopSheetState extends State<StopSheet> {
                                           elevation: 0
                                         ),
                                         child: Icon(
-                                          (_isFavorited ?? false)?  Icons.favorite : Icons.favorite_border, 
-                                          color: (_isFavorited ?? false)? Colors.red : getColor(context, ColorType.secondaryButtonText),
+                                          (_isFavorite ?? false)?  Icons.favorite : Icons.favorite_border, 
+                                          color: (_isFavorite ?? false)? Colors.red : getColor(context, ColorType.secondaryButtonText),
                                           size: 20,
                                         ), 
                                       ),


### PR DESCRIPTION
Added a variable to track favorited stop markers (_displayedFavoriteStopMarkers) for persistent-displayed favorited stops. This is then updated alongside stop markers or whenever the user favorites/unfavorites a bus stop. also -- I have not tested this on iOS as I do not have an iPhone.

**Potential concern**: it looks like stops where multiple busses stop have a marker for each bus route (such as the CCTC Chemistry stop, which has 8 markers), and this system currently favorites all of them and has them all persistently display when the stop is favorited, which could be a performance concern.