### PR TITLE
Ensure notif reqests get sent

### DIFF
--- a/lib/services/incoming_bus_reminder_service.dart
+++ b/lib/services/incoming_bus_reminder_service.dart
@@ -76,6 +76,30 @@ class IncomingBusReminderService {
     await _unsetReminder(token: token, stpid: stpid, rtid: rtid);
   }
 
+  static Future<void> checkReminders(
+    List<RemindersModification> modifications,
+  ) async {
+    // TODO: avoid excessive setup work
+    await _completeSetup();
+    final token = _serverToken();
+    if (token == null) throw Exception("missing token");
+
+    // List for checking if every reminder modification has been set
+    List<bool> added = List.generate(modifications.length, (i) => modifications[i] is RemoveReminder);
+
+    for (final reminder in await _activeReminders(token: token)) {
+      for (int i = 0; i < modifications.length; ++i) {
+        if (reminder.stpid == modifications[i].encode()["stpid"] && reminder.rtid == modifications[i].encode()["rtid"]) {
+          added[i] = modifications[i] is AddReminder;
+          if (added[i] is RemoveReminder) throw Exception("backend not updated");
+          break;
+        }
+      }
+    }
+
+    if (added.contains(false)) throw Exception("backend not updated");
+  }
+
   static Future<void> modifyReminders(
     List<RemindersModification> modifications,
   ) async {

--- a/lib/services/incoming_bus_reminder_service.dart
+++ b/lib/services/incoming_bus_reminder_service.dart
@@ -91,8 +91,8 @@ class IncomingBusReminderService {
 
     for (final reminder in await _activeReminders(token: token)) {
       for (int i = 0; i < modifications.length; ++i) {
-        if (reminder.stpid == modifications[i].encode()["stpid"] && reminder.rtid == modifications[i].encode()["rtid"]) {
-          if (added[i] is RemoveReminder) throw Exception("backend not updated");
+        if (reminder.stpid == modifications[i].stopID && reminder.rtid == modifications[i].routeID) {
+          if (modifications[i] is RemoveReminder) throw Exception("backend not updated");
           added[i] = modifications[i] is AddReminder;
           break;
         }
@@ -241,6 +241,8 @@ Future<void> _notifyMeLater({required String token}) async {
 
 /// Used in the `modifyReminders` method of `IncomingBusReminderService`
 sealed class RemindersModification {
+  String get stopID;
+  String get routeID;
   Map<String, dynamic> encode();
 }
 
@@ -249,6 +251,14 @@ class AddReminder extends RemindersModification {
 
   String stpid, rtid;
   int thresh;
+
+  @override
+  String get stopID => stpid;
+
+  @override
+  String get routeID => rtid;
+
+  int get threshold => thresh;
 
   @override
   Map<String, dynamic> encode() {
@@ -260,6 +270,8 @@ class RemoveReminder extends RemindersModification {
   RemoveReminder({required this.stpid, required this.rtid});
 
   String stpid, rtid;
+  String get stopID => stpid;
+  String get routeID => rtid;
 
   @override
   Map<String, dynamic> encode() {

--- a/lib/services/incoming_bus_reminder_service.dart
+++ b/lib/services/incoming_bus_reminder_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:bluebus/constants.dart';
 import 'package:bluebus/services/notification_service.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:http/http.dart' as http;
@@ -76,30 +77,6 @@ class IncomingBusReminderService {
     await _unsetReminder(token: token, stpid: stpid, rtid: rtid);
   }
 
-  static Future<void> checkReminders(
-    List<RemindersModification> modifications,
-  ) async {
-    // TODO: avoid excessive setup work
-    await _completeSetup();
-    final token = _serverToken();
-    if (token == null) throw Exception("missing token");
-
-    // List for checking if every reminder modification has been set
-    List<bool> added = List.generate(modifications.length, (i) => modifications[i] is RemoveReminder);
-
-    for (final reminder in await _activeReminders(token: token)) {
-      for (int i = 0; i < modifications.length; ++i) {
-        if (reminder.stpid == modifications[i].encode()["stpid"] && reminder.rtid == modifications[i].encode()["rtid"]) {
-          added[i] = modifications[i] is AddReminder;
-          if (added[i] is RemoveReminder) throw Exception("backend not updated");
-          break;
-        }
-      }
-    }
-
-    if (added.contains(false)) throw Exception("backend not updated");
-  }
-
   static Future<void> modifyReminders(
     List<RemindersModification> modifications,
   ) async {
@@ -108,6 +85,21 @@ class IncomingBusReminderService {
     final token = _serverToken();
     if (token == null) throw Exception("missing token");
     await _modifyReminders(token: token, modifications: modifications);
+
+    // List for checking if every reminder modification has been set
+    List<bool> added = List.generate(modifications.length, (i) => modifications[i] is RemoveReminder);
+
+    for (final reminder in await _activeReminders(token: token)) {
+      for (int i = 0; i < modifications.length; ++i) {
+        if (reminder.stpid == modifications[i].encode()["stpid"] && reminder.rtid == modifications[i].encode()["rtid"]) {
+          if (added[i] is RemoveReminder) throw Exception("backend not updated");
+          added[i] = modifications[i] is AddReminder;
+          break;
+        }
+      }
+    }
+
+    if (added.contains(false)) throw Exception("backend not updated");
   }
 
   static Future<bool> isActiveReminder(String stpid, String rtid) async {

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -324,9 +324,7 @@ class _StopSheetState extends State<StopSheet> {
               arrivingBuses.sort(
                 (lhs, rhs) => (int.tryParse(lhs.prediction) ?? 0).compareTo(int.tryParse(rhs.prediction) ?? 0)
               );
-              if (_isFavorited == null) {
-                _isFavorited = snapshot.data!.$2;
-              }
+              _isFavorited ??= snapshot.data!.$2;
             }
 
             double initialSize = 0.9;
@@ -543,7 +541,6 @@ class _StopSheetState extends State<StopSheet> {
                                                       crossAxisAlignment:
                                                           CrossAxisAlignment.start,
                                                       children: [
-                                                        (arrivingBuses.length == 0)
                                                             ?
                                                               Center(
                                                                 child: Column(

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -6,6 +6,7 @@ import 'package:bluebus/widgets/dialog.dart';
 import 'package:bluebus/widgets/refresh_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../constants.dart';
 import '../services/route_color_service.dart';
 import '../models/bus_stop.dart';
@@ -263,34 +264,33 @@ class _StopSheetState extends State<StopSheet> {
   void initState() {
     super.initState();
     loadedStopData = fetchStopData(widget.stopID);
-    imageBusStop =
-        (widget.stopID == "C250") ||
-        (widget.stopID == "N406") ||
-        (widget.stopID == "N405") ||
-        (widget.stopID == "N550") ||
-        (widget.stopID == "N551") ||
-        (widget.stopID == "N553") ||
-        (widget.stopID == "C251");
-    if (widget.stopID == "C250") {
-      imagePath = "assets/CCTC.jpg";
-    }
-    if (widget.stopID == "C251") {
-      imagePath = "assets/CCTC_Ruthven.jpg";
-    }
-    if (widget.stopID == "N406") {
-      imagePath = "assets/FXB_outbound.jpg";
-    }
-    if (widget.stopID == "N405") {
-      imagePath = "assets/FXB_inbound.jpg";
-    }
-    if (widget.stopID == "N550") {
-      imagePath = "assets/Pierpont.jpg";
-    }
-    if (widget.stopID == "N551") {
-      imagePath = "assets/PierpontBursley.jpg";
-    }
-    if (widget.stopID == "N553") {
-      imagePath = "assets/PierpontNorthwood.jpg";
+    imageBusStop = true;
+
+    switch (widget.stopID) {
+      case "C250":
+        imagePath = "assets/CCTC.jpg";
+        break;
+      case "C251":
+        imagePath = "assets/CCTC_Ruthven.jpg";
+        break;
+      case "N406":
+        imagePath = "assets/FXB_outbound.jpg";
+        break;
+      case "N405":
+        imagePath = "assets/FXB_inbound.jpg";
+        break;
+      case "N550":
+        imagePath = "assets/Pierpont.jpg";
+        break;
+      case "N551":
+        imagePath = "assets/PierpontBursley.jpg";
+        break;
+      case "N553":
+        imagePath = "assets/PierpontNorthwood.jpg";
+        break;
+      default:
+        imageBusStop = false;
+        break;
     }
   }
 
@@ -837,14 +837,36 @@ class _ReminderFormState extends State<ReminderForm> {
   Set<String> activeRtids = {};
   /// ones that have been selected to be added / removed
   Set<String> rtidsToChange = {};
-  int reminderThresh = 5;
+  int reminderThresh = -1;
 
   // exists to ensure the notification button isn't pressed multiple times 
   // while waiting for the response
   bool _isProcessing = false;
 
+  // Save reminder threshold to persistent storage
+  Future<void> _saveReminderThreshold() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt('reminder_thresh', reminderThresh);
+  }
+
+  // Load reminder threshold from persistent storage
+  Future<int> _loadReminderThreshold() async {
+    final prefs = await SharedPreferences.getInstance();
+    final savedThresh = prefs.getInt('reminder_thresh') ?? 5;
+    return savedThresh;
+  }
+
   @override
   Widget build(BuildContext context) {
+    if (reminderThresh < 0) {
+      _loadReminderThreshold().then((int savedThresh) {
+        setState(() {
+          reminderThresh = savedThresh;
+        });
+      }).catchError((error, stack) {
+        
+      });
+    }
     return FutureBuilder(
       future: reminderInfoFuture,
       builder: (context, snapshot) {
@@ -1076,6 +1098,7 @@ class _ReminderFormState extends State<ReminderForm> {
                       onPressed: _isProcessing ? null : () async {
                         // is processing lets us make sure no one spams the button
                         setState(() => _isProcessing = true);
+                        await _saveReminderThreshold();
                       
                         List<RemindersModification> modifications = [];
                         for (String rtid in routesToShow) {
@@ -1095,10 +1118,10 @@ class _ReminderFormState extends State<ReminderForm> {
                           if (!context.mounted) return;
                           Navigator.pop(context);
                         } on Exception {
-                          showDialog(
-                            context: context,
-                            builder: (context) => SimpleDialog(
-                              title: Text("Notification request\n couldn't be sent\n", textAlign: TextAlign.center,)),
+                          showMaizebusOKDialog(
+                            contextIn: context,
+                            title: Text("Failed to set reminders"),
+                            content: Text("If this error is persistent, please send us feedback through the feedback form in the settings page"),
                           );
                         }
                         setState(() => _isProcessing = false);

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -1092,13 +1092,14 @@ class _ReminderFormState extends State<ReminderForm> {
 
                         try {
                           await IncomingBusReminderService.modifyReminders(modifications);                  
+                          await IncomingBusReminderService.checkReminders(modifications);                  
                           if (!context.mounted) return;
                           Navigator.pop(context);
                         } on Exception catch (e) {
                           showDialog(
                             context: context,
                             builder: (context) => SimpleDialog(
-                              title: Text("Failed!\n${e.toString()}")),
+                              title: Text("Notification request couldn't be sent\n")),
                           );
                         }
                         setState(() => _isProcessing = false);

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -1095,11 +1095,11 @@ class _ReminderFormState extends State<ReminderForm> {
                           await IncomingBusReminderService.checkReminders(modifications);                  
                           if (!context.mounted) return;
                           Navigator.pop(context);
-                        } on Exception catch (e) {
+                        } on Exception {
                           showDialog(
                             context: context,
                             builder: (context) => SimpleDialog(
-                              title: Text("Notification request couldn't be sent\n")),
+                              title: Text("Notification request\n couldn't be sent\n", textAlign: TextAlign.center,)),
                           );
                         }
                         setState(() => _isProcessing = false);

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -1092,7 +1092,6 @@ class _ReminderFormState extends State<ReminderForm> {
 
                         try {
                           await IncomingBusReminderService.modifyReminders(modifications);                  
-                          await IncomingBusReminderService.checkReminders(modifications);                  
                           if (!context.mounted) return;
                           Navigator.pop(context);
                         } on Exception {

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -541,6 +541,7 @@ class _StopSheetState extends State<StopSheet> {
                                                       crossAxisAlignment:
                                                           CrossAxisAlignment.start,
                                                       children: [
+                                                        (arrivingBuses.isEmpty)
                                                             ?
                                                               Center(
                                                                 child: Column(
@@ -1115,11 +1116,13 @@ class _ReminderFormState extends State<ReminderForm> {
                           if (!context.mounted) return;
                           Navigator.pop(context);
                         } on Exception {
-                          showMaizebusOKDialog(
-                            contextIn: context,
-                            title: Text("Failed to set reminders"),
-                            content: Text("If this error is persistent, please send us feedback through the feedback form in the settings page"),
-                          );
+                          if (context.mounted) {
+                            showMaizebusOKDialog(
+                              contextIn: context,
+                              title: Text("Failed to set reminders"),
+                              content: Text("If this error is persistent, please send us feedback through the feedback form in the settings page"),
+                            );
+                          }
                         }
                         setState(() => _isProcessing = false);
                       },

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -1106,8 +1106,8 @@ class _ReminderFormState extends State<ReminderForm> {
                           if (context.mounted) {
                             showMaizebusOKDialog(
                               contextIn: context,
-                              title: Text("Failed to set reminders"),
-                              content: Text("If this error is persistent, please send us feedback through the feedback form in the settings page"),
+                              title: "Failed to set reminders",
+                              content: "If this error is persistent, please send us feedback through the feedback form in the settings page",
                             );
                           }
                         }


### PR DESCRIPTION
## Description
When setting notification requests for a stop, the app checks to make sure the notification list has the reminders to be added and omits the reminders to be deleted. Otherwise, a popup appears telling the user the notification request could not be sent.

## Type of Change
- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Refactor / code improvement
- [ ] Dependency / build update
- [ ] Documentation
- [ ] Other (explain)

## Changes Made
- Flutter:
  - `stop_sheet.dart` now displays a different error message
  - `modifyReminders()` in `incoming_bus_reminder_service.dart` now checks backend
  - The position of the reminder slider is now saved between requests

## Testing Done
**Flutter:**
- [ ] `flutter analyze` and `flutter format` passed
- [ ] Unit / widget tests added or updated (`flutter test`)
- [ ] Tested on:
  - [ ] iOS Simulator
  - [x] Android Emulator
  - [ ] Physical device
- [ ] Firebase notifications tested (foreground, background, killed app)
- [ ] Offline mode / cache behavior checked

**Backend:**
- [ ] TypeScript compilation & linting passed
- [ ] Unit / integration tests passed
- [ ] Tested API endpoints (Postman / curl)
- [ ] Firebase Admin SDK behavior verified

**Integration:**
- [ ] Flutter app successfully calls updated backend endpoints
- [ ] End-to-end flow tested (e.g., bus arrival → notification)

## Checklist
- [ ] Commit messages follow Conventional Commits
- [ ] PR title follows `[type](scope): short description`
- [x] No `print()` / `console.log()` left in production code
- [x] Code follows project style (Dart + ESLint/Prettier for TS)
- [x] Secrets / keys not committed
