### PR TITLE
42-have full building list be downloaded at install instead of every time the search feature is used

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = 4LLPM7NY5C;
+				DEVELOPMENT_TEAM = TY8BMZ5C7D;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MaizeBus;
@@ -506,7 +506,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ishankumar.maizebus;
+				PRODUCT_BUNDLE_IDENTIFIER = com.siddhant.maizebus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -691,7 +691,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = 4LLPM7NY5C;
+				DEVELOPMENT_TEAM = TY8BMZ5C7D;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MaizeBus;
@@ -702,7 +702,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ishankumar.maizebus;
+				PRODUCT_BUNDLE_IDENTIFIER = com.siddhant.maizebus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -724,7 +724,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = 5;
-				DEVELOPMENT_TEAM = 4LLPM7NY5C;
+				DEVELOPMENT_TEAM = TY8BMZ5C7D;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = MaizeBus;
@@ -735,7 +735,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.ishankumar.maizebus;
+				PRODUCT_BUNDLE_IDENTIFIER = com.siddhant.maizebus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>development</string>
-</dict>
+<dict/>
 </plist>

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -2,6 +2,7 @@ import 'constants.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 List<Location> globalStopLocs = [];
+List<Location> globalBuildingLocs = [];
 
 // the global app padding
 // don't modify these here, instead use the helper function in map_screen.dart that sets these based on phone type and safe area insets

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -313,11 +313,13 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
     // LOADS BOTH STOP TYPES
     final uriStops = Uri.parse(BACKEND_URL + '/getAllStops');
     final uriRideStops = Uri.parse(BACKEND_URL + '/getAllRideStops');
+    final uriBuildings = Uri.parse(BACKEND_URL + '/getBuildingLocations');
 
     // Calling in parallel
     final responses = await Future.wait([
       http.get(uriStops),
       http.get(uriRideStops),
+      http.get(uriBuildings),
     ]);
 
     // Helper function to parse a response into a List<Location>
@@ -355,6 +357,28 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
       ...parseLocations(responses[0]),
       ...parseLocations(responses[1]),
     ];
+
+    final buildingResponse = responses[2];
+    if (buildingResponse.statusCode == 200 &&
+        buildingResponse.body.trim().isNotEmpty &&
+        buildingResponse.body.trim() != '{}') {
+      final buildingLocations =
+          jsonDecode(buildingResponse.body) as List<dynamic>;
+      globalBuildingLocs = buildingLocations.map((building) {
+        final name = building['buildingName'] as String;
+        final abbrev = building['abbrev'] as String?;
+        final altName = building['altName'] as String?;
+        final lat = building['lat'] as double;
+        final long = building['long'] as double;
+        return Location(
+          name,
+          (abbrev != null) ? abbrev : "",
+          [if (abbrev != null) abbrev, if (altName != null) altName],
+          false,
+          latlng: LatLng(lat, long),
+        );
+      }).toList();
+    }
 
     globalStopLocs = stopLocs;
   }

--- a/lib/widgets/search_sheet_main.dart
+++ b/lib/widgets/search_sheet_main.dart
@@ -35,6 +35,7 @@ class LocationSearchBar extends HookWidget {
     }, [focusNode]);
     final searchQuery = useState('');
 
+    // Parse Buildings
     final locations = useMemoized(() async {
       final allLocs = [...globalBuildingLocs, ...globalStopLocs];
       return allLocs;

--- a/lib/widgets/search_sheet_main.dart
+++ b/lib/widgets/search_sheet_main.dart
@@ -35,97 +35,10 @@ class LocationSearchBar extends HookWidget {
     }, [focusNode]);
     final searchQuery = useState('');
 
-    final refreshKey = useState(0);
-
     final locations = useMemoized(() async {
-      try {
-        final buildingResponse = await http.get(
-          Uri.parse(BACKEND_URL + '/getBuildingLocations'),
-        );
-        List<Location> buildingLocs = [];
-        if (buildingResponse.statusCode == 200 &&
-            buildingResponse.body.trim().isNotEmpty &&
-            buildingResponse.body.trim() != '{}') {
-          final buildingLocations =
-              jsonDecode(buildingResponse.body) as List<dynamic>;
-          buildingLocs = buildingLocations.map((building) {
-            final name = building['buildingName'] as String;
-            final abbrev = building['abbrev'] as String?;
-            final altName = building['altName'] as String?;
-            final lat = building['lat'] as double;
-            final long = building['long'] as double;
-            return Location(
-              name,
-              (abbrev != null) ? abbrev : "",
-              [if (abbrev != null) abbrev, if (altName != null) altName],
-              false,
-              latlng: LatLng(lat, long),
-            );
-          }).toList();
-        }
-
-        // TODO: this code is DUPLICATED. We need to refactor to avoid duplication.
-        // LOADS BOTH STOP TYPES
-        final uriStops = Uri.parse(BACKEND_URL + '/getAllStops');
-        final uriRideStops = Uri.parse(BACKEND_URL + '/getAllRideStops');
-
-        // Calling in parallel
-        final responses = await Future.wait([
-          http.get(uriStops),
-          http.get(uriRideStops),
-        ]);
-
-        // Helper function to parse a response into a List<Location>
-        // This prevents copying/pasting the parsing logic.
-        List<Location> parseLocations(http.Response response) {
-          if (response.statusCode == 200 &&
-              response.body.trim().isNotEmpty &&
-              response.body.trim() != '{}') {
-            
-            final stopList = jsonDecode(response.body) as List<dynamic>;
-            
-            return stopList.map((stop) {
-              final name = stop['name'] as String;
-              final aliases = [
-                name.split(' ').map((w) => w.isNotEmpty ? w[0] : '').join(),
-              ];
-              final stopId = stop['stpid'] as String?;
-              final lat = stop['lat'] as double?;
-              final lon = stop['lon'] as double?;
-              
-              return Location(
-                name,
-                (stopId != null) ? stopId : "",
-                aliases,
-                true,
-                stopId: stopId,
-                latlng: (lat != null && lon != null) ? LatLng(lat, lon) : null,
-              );
-            }).toList();
-          }
-          return []; // Return empty list if call failed or body is empty
-        }
-
-        // parse both and merge
-        List<Location> stopLocs = [
-          ...parseLocations(responses[0]),
-          ...parseLocations(responses[1]),
-        ];
-
-        globalStopLocs = stopLocs;
-
-        final allLocs = [...buildingLocs, ...stopLocs];
-        if (allLocs.isEmpty) {
-          refreshKey.value++;
-        }
-
-        return allLocs;
-      } catch (e) {
-        print('Failed to fetch locations: $e');
-        refreshKey.value++;
-        return <Location>[];
-      }
-    }, [refreshKey.value]);
+      final allLocs = [...globalBuildingLocs, ...globalStopLocs];
+      return allLocs;
+    }, []);
 
     Map<String, Set<Location>> buildNgramIndex(
       List<Location> locations, {
@@ -207,15 +120,13 @@ class LocationSearchBar extends HookWidget {
         SizedBox(
           height: 50,
           child: DecoratedBox(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(56),
-            ),
+            decoration: BoxDecoration(borderRadius: BorderRadius.circular(56)),
             child: TextField(
               textAlignVertical: TextAlignVertical.center,
               textInputAction: TextInputAction.go,
-              style:  TextStyle(
+              style: TextStyle(
                 color: getColor(context, ColorType.opposite).withAlpha(204),
-                fontSize: 22
+                fontSize: 22,
               ),
               autofocus: true,
               controller: controller,
@@ -312,12 +223,16 @@ class LocationSearchBar extends HookWidget {
                         ? Icon(
                             Icons.hail,
                             size: 40,
-                            color: isDarkMode(context) ? Color.fromARGB(150, 255, 255, 255) : Color.fromARGB(150, 0, 0, 0),
+                            color: isDarkMode(context)
+                                ? Color.fromARGB(150, 255, 255, 255)
+                                : Color.fromARGB(150, 0, 0, 0),
                           )
                         : Icon(
                             Icons.business_rounded,
                             size: 40,
-                            color: isDarkMode(context) ? Color.fromARGB(150, 255, 255, 255) : Color.fromARGB(150, 0, 0, 0),
+                            color: isDarkMode(context)
+                                ? Color.fromARGB(150, 255, 255, 255)
+                                : Color.fromARGB(150, 0, 0, 0),
                           ),
                     onTap: () {
                       controller.text = loc.name;
@@ -372,7 +287,7 @@ class _SearchSheetState extends State<SearchSheet> {
           topLeft: Radius.circular(30),
           topRight: Radius.circular(30),
         ),
-        boxShadow: [SheetBoxShadow]
+        boxShadow: [SheetBoxShadow],
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -421,7 +336,7 @@ class _SearchSheetState extends State<SearchSheet> {
                     color: getColor(context, ColorType.inputText),
                   ),
                 ),
-                
+
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.all(Radius.circular(56.0)),
                   borderSide: BorderSide(color: Colors.transparent, width: 0),


### PR DESCRIPTION
Previously, the building list was fetched from the backend every time the search button was tapped. Now it is cached at startup in a global variable and reused in the search sheet, making search snappy.