### PR TITLE
feat(notif): Swipe to delete notifs on map screen

### DIFF
--- a/lib/widgets/reminder_widgets.dart
+++ b/lib/widgets/reminder_widgets.dart
@@ -207,11 +207,55 @@ class _ReminderWidgetsState extends State<ReminderWidgets> {
               ),
             );
             children.addAll(
+              // the dismissible widgets that show each reminder, swiping left deletes the reminder
               reminders.map(
-                (r) => ReminderWidget(
-                  rtid: r.rtid,
-                  stopName: getStopNameFromID(r.stpid),
-                  eta: r.eta,
+                (r) => Dismissible(
+                  key: Key('${r.stpid}|${r.rtid}'),
+                  direction: DismissDirection.endToStart,
+                  // the red background with the trash/delete icon that shows when swiping
+                  background: Container(
+                    color: Colors.red, // red background for delete action
+                    alignment: Alignment.centerRight,
+                    padding: EdgeInsets.only(right: 20.0),
+                    child: Icon(Icons.delete, color: Colors.white), // white trash icon
+                  ),
+                  // when the user swipes enough to dismiss
+                  // try to remove the reminder from the service
+                  // if it fails put the widget back
+                  confirmDismiss: (direction) async {
+                    try {
+                      await IncomingBusReminderService.removeReminder(
+                        r.stpid,
+                        r.rtid,
+                      );
+                      return true;
+                    } catch (e) {
+                      if (kDebugMode) {
+                        print('Failed to remove reminder: $e');
+                      }
+                      return false;
+                    }
+                  },
+                  // if the reminder was successfully removed from the service
+                  // also remove it from the local list so the widget disappears immediately
+                  onDismissed: (_) {
+                    // Remove from local list immediately so the dismissed
+                    // widget leaves the tree before the async refresh.
+                    setState(() {
+                      reminders.removeWhere(
+                        (x) => x.stpid == r.stpid && x.rtid == r.rtid,
+                      );
+                    });
+                    _resetDataFuture();
+                  },
+                  // the actual reminder widget
+                  child: ReminderWidget(
+                    stpid: r.stpid,
+                    rtid: r.rtid,
+                    stopName: getStopNameFromID(r.stpid),
+                    eta: r.eta,
+                    onDismissed: _resetDataFuture,
+                  ),
                 ),
               ),
             );
@@ -231,14 +275,18 @@ class _ReminderWidgetsState extends State<ReminderWidgets> {
 class ReminderWidget extends StatelessWidget {
   const ReminderWidget({
     super.key,
+    required this.stpid,
     required this.rtid,
     required this.stopName,
     required this.eta,
+    this.onDismissed,
   });
 
+  final String stpid;
   final String rtid;
   final String stopName;
   final int? eta;
+  final VoidCallback? onDismissed; // called when the reminder is dismissed
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/reminder_widgets.dart
+++ b/lib/widgets/reminder_widgets.dart
@@ -207,66 +207,39 @@ class _ReminderWidgetsState extends State<ReminderWidgets> {
               ),
             );
             children.addAll(
-              // the dismissible widgets that show each reminder, swiping left deletes the reminder
+              // the dismissible widgets that show each reminder, swiping left deletes the reminder.
+              // using a custom implementation instead of Dismissible
               reminders.map(
-                (r) => Stack(
-                  children: [
-                    Positioned.fill(
-                      child: Container(
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.all(Radius.circular(30)),
-                          color: Colors.red,
-                        ),
-                        alignment: Alignment.centerRight,
-                        padding: EdgeInsets.only(right: 20.0),
-                        child: Icon(Icons.delete, color: Colors.white),
-                      ),
-                    ),
-                    Dismissible(
-                      key: Key('${r.stpid}|${r.rtid}'),
-                      direction: DismissDirection.endToStart,
-                      background: const SizedBox.shrink(),
-                      // when the user swipes enough to dismiss
-                      // try to remove the reminder from the service
-                      // if it fails put the widget back
-                      confirmDismiss: (direction) async {
-                        try {
-                          await IncomingBusReminderService.removeReminder(
-                            r.stpid,
-                            r.rtid,
-                          );
-                          return true;
-                        } catch (e) {
-                          if (kDebugMode) {
-                            print('Failed to remove reminder: $e');
-                          }
-                          return false;
-                        }
-                      },
-                      // if the reminder was successfully removed from the service
-                      // also remove it from the local list so the widget disappears immediately
-                      onDismissed: (_) {
-                        // Remove from local list immediately so the dismissed
-                        // widget leaves the tree before the async refresh.
-                        setState(() {
-                          reminders.removeWhere(
-                            (x) => x.stpid == r.stpid && x.rtid == r.rtid,
-                          );
-                        });
-                        _resetDataFuture();
-                      },
-                      // the actual reminder widget
-                      child: ReminderWidget(
-                        stpid: r.stpid,
-                        rtid: r.rtid,
-                        stopName: getStopNameFromID(r.stpid),
-                        eta: r.eta,
-                        onDismissed: _resetDataFuture,
-                      ),
-                    ),
-                    ],
-                  ),
+                (r) => _DismissibleReminder(
+                  key: Key('${r.stpid}|${r.rtid}'),
+                  stpid: r.stpid,
+                  rtid: r.rtid,
+                  stopName: getStopNameFromID(r.stpid),
+                  eta: r.eta,
+                  confirmDismiss: () async {
+                    try {
+                      await IncomingBusReminderService.removeReminder(
+                        r.stpid,
+                        r.rtid,
+                      );
+                      return true;
+                    } catch (e) {
+                      if (kDebugMode) {
+                        print('Failed to remove reminder: $e');
+                      }
+                      return false;
+                    }
+                  },
+                  onDismissed: () {
+                    setState(() {
+                      reminders.removeWhere(
+                        (x) => x.stpid == r.stpid && x.rtid == r.rtid,
+                      );
+                    });
+                    _resetDataFuture();
+                  },
                 ),
+              ),
             );
           }
         }
@@ -348,6 +321,180 @@ class ReminderWidgetCard extends StatelessWidget {
       ),
       padding: EdgeInsetsDirectional.all(15),
       child: child,
+    );
+  }
+}
+
+/// Custom swipe for dismissing notifications:
+/// white card slides left revealing the red behind it,
+/// then on dismiss both animate off screen together (red pulled along by the card).
+class _DismissibleReminder extends StatefulWidget {
+  const _DismissibleReminder({
+    super.key,
+    required this.stpid,
+    required this.rtid,
+    required this.stopName,
+    required this.eta,
+    required this.confirmDismiss,
+    required this.onDismissed,
+  });
+
+  final String stpid;
+  final String rtid;
+  final String stopName;
+  final int? eta;
+  final Future<bool> Function() confirmDismiss; // returns whether the dismissal should proceed (like if the reminder was successfully deleted)
+  final VoidCallback onDismissed; // called after the dismiss animation completes and the widget is removed from the tree
+
+  @override
+  State<_DismissibleReminder> createState() => __DismissibleReminderState();
+}
+
+
+class __DismissibleReminderState extends State<_DismissibleReminder>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _curve;
+
+
+  // current drag offset (always <= 0)
+  double _dragOffset = 0.0;
+  // offset captured when the dismiss animation starts
+  double _capturedOffset = 0.0;
+  bool _dismissing = false;
+  bool _dismissed = false;
+  // row width measured by LayoutBuilder
+  double _rowWidth = 300.0;
+
+
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    )..addListener(() {
+        if (mounted) setState(() {});
+      });
+    _curve = CurvedAnimation(parent: _controller, curve: Curves.easeOut);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+
+  // white card: slides from capturedOffset to -rowWidth
+  double get _whiteX {
+    if (_dismissing) {
+      return _capturedOffset + _curve.value * (-_rowWidth - _capturedOffset);
+    }
+    return _dragOffset;
+  }
+
+
+
+  // red background: stays at 0 during drag, then accelerates to -rowWidth on dismiss
+  double get _redX {
+    if (_dismissing) {
+      return _curve.value * (-_rowWidth);
+    }
+    return 0.0;
+  }
+
+
+
+  // updates drag offset during horizontal drag, ignoring drags if already dismissing
+  void _onDragUpdate(DragUpdateDetails details) {
+    if (_dismissing) return;
+    setState(() {
+      _dragOffset = (_dragOffset + details.delta.dx).clamp(
+        -double.infinity,
+        0.0,
+      );
+    });
+  }
+
+
+
+  // handles drag end, checking if the drag was far/fast enough to 
+  // dismiss, then either starts the dismiss animation or resets the drag offset
+  Future<void> _onDragEnd(DragEndDetails details) async {
+    if (_dismissing) return;
+    final velocity = details.velocity.pixelsPerSecond.dx;
+    // dismiss if dragged more than 35% of the way or swiped left fast enough, otherwise reset
+    if (_dragOffset.abs() > _rowWidth * 0.35 || velocity < -700) {
+      final confirmed = await widget.confirmDismiss();
+      if (!mounted) return;
+      if (!confirmed) {
+        setState(() {
+          _dragOffset = 0.0; // reset position if dismissal was not confirmed
+        });
+        return;
+      }
+      _capturedOffset = _dragOffset;
+      setState(() {
+        _dismissing = true; // trigger animation to start sliding both widgets left
+      });
+      await _controller.forward();
+      if (!mounted) return;
+      setState(() {
+        _dismissed = true; // hide the widget after animation completes
+      });
+      widget.onDismissed();
+    } else {
+      setState(() {
+        _dragOffset = 0.0; // reset position if dismissal was not confirmed
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed) return const SizedBox.shrink(); // don't build anything if dismissed
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth.isFinite) {
+          _rowWidth = constraints.maxWidth; // update row width based on layout constraints
+        }
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            // red delete background — revealed as white slides, pulled off screen on dismiss
+            Positioned.fill(
+              child: Transform.translate(
+                offset: Offset(_redX, 0),
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.all(Radius.circular(30)),
+                    color: Colors.red,
+                  ),
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 20.0),
+                  child: const Icon(Icons.delete, color: Colors.white),
+                ),
+              ),
+            ),
+            // white notification card — follows drag, animates off screen on dismiss
+            Transform.translate(
+              offset: Offset(_whiteX, 0),
+              child: GestureDetector(
+                onHorizontalDragUpdate: _onDragUpdate,
+                onHorizontalDragEnd: _onDragEnd,
+                child: ReminderWidget(
+                  stpid: widget.stpid,
+                  rtid: widget.rtid,
+                  stopName: widget.stopName,
+                  eta: widget.eta,
+                ),
+              ),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/widgets/reminder_widgets.dart
+++ b/lib/widgets/reminder_widgets.dart
@@ -209,52 +209,64 @@ class _ReminderWidgetsState extends State<ReminderWidgets> {
             children.addAll(
               // the dismissible widgets that show each reminder, swiping left deletes the reminder
               reminders.map(
-                (r) => Dismissible(
-                  key: Key('${r.stpid}|${r.rtid}'),
-                  direction: DismissDirection.endToStart,
-                  // the red background with the trash/delete icon that shows when swiping
-                  background: Container(
-                    color: Colors.red, // red background for delete action
-                    alignment: Alignment.centerRight,
-                    padding: EdgeInsets.only(right: 20.0),
-                    child: Icon(Icons.delete, color: Colors.white), // white trash icon
-                  ),
-                  // when the user swipes enough to dismiss
-                  // try to remove the reminder from the service
-                  // if it fails put the widget back
-                  confirmDismiss: (direction) async {
-                    try {
-                      await IncomingBusReminderService.removeReminder(
-                        r.stpid,
-                        r.rtid,
-                      );
-                      return true;
-                    } catch (e) {
-                      if (kDebugMode) {
-                        print('Failed to remove reminder: $e');
-                      }
-                      return false;
-                    }
-                  },
-                  // if the reminder was successfully removed from the service
-                  // also remove it from the local list so the widget disappears immediately
-                  onDismissed: (_) {
-                    // Remove from local list immediately so the dismissed
-                    // widget leaves the tree before the async refresh.
-                    setState(() {
-                      reminders.removeWhere(
-                        (x) => x.stpid == r.stpid && x.rtid == r.rtid,
-                      );
-                    });
-                    _resetDataFuture();
-                  },
-                  // the actual reminder widget
-                  child: ReminderWidget(
-                    stpid: r.stpid,
-                    rtid: r.rtid,
-                    stopName: getStopNameFromID(r.stpid),
-                    eta: r.eta,
-                    onDismissed: _resetDataFuture,
+                (r) => ClipRRect(
+                  borderRadius: BorderRadius.all(Radius.circular(30)),
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.all(Radius.circular(30)),
+                            color: Colors.red,
+                          ),
+                          alignment: Alignment.centerRight,
+                          padding: EdgeInsets.only(right: 20.0),
+                          child: Icon(Icons.delete, color: Colors.white),
+                        ),
+                      ),
+                      Dismissible(
+                        key: Key('${r.stpid}|${r.rtid}'),
+                        direction: DismissDirection.endToStart,
+                        background: const SizedBox.shrink(),
+                        // when the user swipes enough to dismiss
+                        // try to remove the reminder from the service
+                        // if it fails put the widget back
+                        confirmDismiss: (direction) async {
+                          try {
+                            await IncomingBusReminderService.removeReminder(
+                              r.stpid,
+                              r.rtid,
+                            );
+                            return true;
+                          } catch (e) {
+                            if (kDebugMode) {
+                              print('Failed to remove reminder: $e');
+                            }
+                            return false;
+                          }
+                        },
+                        // if the reminder was successfully removed from the service
+                        // also remove it from the local list so the widget disappears immediately
+                        onDismissed: (_) {
+                          // Remove from local list immediately so the dismissed
+                          // widget leaves the tree before the async refresh.
+                          setState(() {
+                            reminders.removeWhere(
+                              (x) => x.stpid == r.stpid && x.rtid == r.rtid,
+                            );
+                          });
+                          _resetDataFuture();
+                        },
+                        // the actual reminder widget
+                        child: ReminderWidget(
+                          stpid: r.stpid,
+                          rtid: r.rtid,
+                          stopName: getStopNameFromID(r.stpid),
+                          eta: r.eta,
+                          onDismissed: _resetDataFuture,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/widgets/reminder_widgets.dart
+++ b/lib/widgets/reminder_widgets.dart
@@ -209,67 +209,64 @@ class _ReminderWidgetsState extends State<ReminderWidgets> {
             children.addAll(
               // the dismissible widgets that show each reminder, swiping left deletes the reminder
               reminders.map(
-                (r) => ClipRRect(
-                  borderRadius: BorderRadius.all(Radius.circular(30)),
-                  child: Stack(
-                    children: [
-                      Positioned.fill(
-                        child: Container(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.all(Radius.circular(30)),
-                            color: Colors.red,
-                          ),
-                          alignment: Alignment.centerRight,
-                          padding: EdgeInsets.only(right: 20.0),
-                          child: Icon(Icons.delete, color: Colors.white),
+                (r) => Stack(
+                  children: [
+                    Positioned.fill(
+                      child: Container(
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.all(Radius.circular(30)),
+                          color: Colors.red,
                         ),
+                        alignment: Alignment.centerRight,
+                        padding: EdgeInsets.only(right: 20.0),
+                        child: Icon(Icons.delete, color: Colors.white),
                       ),
-                      Dismissible(
-                        key: Key('${r.stpid}|${r.rtid}'),
-                        direction: DismissDirection.endToStart,
-                        background: const SizedBox.shrink(),
-                        // when the user swipes enough to dismiss
-                        // try to remove the reminder from the service
-                        // if it fails put the widget back
-                        confirmDismiss: (direction) async {
-                          try {
-                            await IncomingBusReminderService.removeReminder(
-                              r.stpid,
-                              r.rtid,
-                            );
-                            return true;
-                          } catch (e) {
-                            if (kDebugMode) {
-                              print('Failed to remove reminder: $e');
-                            }
-                            return false;
+                    ),
+                    Dismissible(
+                      key: Key('${r.stpid}|${r.rtid}'),
+                      direction: DismissDirection.endToStart,
+                      background: const SizedBox.shrink(),
+                      // when the user swipes enough to dismiss
+                      // try to remove the reminder from the service
+                      // if it fails put the widget back
+                      confirmDismiss: (direction) async {
+                        try {
+                          await IncomingBusReminderService.removeReminder(
+                            r.stpid,
+                            r.rtid,
+                          );
+                          return true;
+                        } catch (e) {
+                          if (kDebugMode) {
+                            print('Failed to remove reminder: $e');
                           }
-                        },
-                        // if the reminder was successfully removed from the service
-                        // also remove it from the local list so the widget disappears immediately
-                        onDismissed: (_) {
-                          // Remove from local list immediately so the dismissed
-                          // widget leaves the tree before the async refresh.
-                          setState(() {
-                            reminders.removeWhere(
-                              (x) => x.stpid == r.stpid && x.rtid == r.rtid,
-                            );
-                          });
-                          _resetDataFuture();
-                        },
-                        // the actual reminder widget
-                        child: ReminderWidget(
-                          stpid: r.stpid,
-                          rtid: r.rtid,
-                          stopName: getStopNameFromID(r.stpid),
-                          eta: r.eta,
-                          onDismissed: _resetDataFuture,
-                        ),
+                          return false;
+                        }
+                      },
+                      // if the reminder was successfully removed from the service
+                      // also remove it from the local list so the widget disappears immediately
+                      onDismissed: (_) {
+                        // Remove from local list immediately so the dismissed
+                        // widget leaves the tree before the async refresh.
+                        setState(() {
+                          reminders.removeWhere(
+                            (x) => x.stpid == r.stpid && x.rtid == r.rtid,
+                          );
+                        });
+                        _resetDataFuture();
+                      },
+                      // the actual reminder widget
+                      child: ReminderWidget(
+                        stpid: r.stpid,
+                        rtid: r.rtid,
+                        stopName: getStopNameFromID(r.stpid),
+                        eta: r.eta,
+                        onDismissed: _resetDataFuture,
                       ),
+                    ),
                     ],
                   ),
                 ),
-              ),
             );
           }
         }

--- a/lib/widgets/reminder_widgets.dart
+++ b/lib/widgets/reminder_widgets.dart
@@ -412,7 +412,7 @@ class __DismissibleReminderState extends State<_DismissibleReminder>
     if (_dismissing) return;
     setState(() {
       _dragOffset = (_dragOffset + details.delta.dx).clamp(
-        -double.infinity,
+        -_rowWidth,
         0.0,
       );
     });


### PR DESCRIPTION
## Description
Add swipe to delete functionality to reminder cards displayed on the maps screen. Users can swipe left on any reminder to delete it. Still needs to be changed to round edges for the UI.

Change was added as there was no easy way to delete reminders prior to this.

## Type of Change
- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [ ] Refactor / code improvement
- [ ] Dependency / build update
- [ ] Documentation
- [ ] Other (explain)

## Changes Made
- Flutter:
  - reminder_widgets.dart
  
  
## Testing Done
**Flutter:**
- [ ] Tested on:
  - [x] iOS Simulator
  - [ ] Android Emulator
  - [ ] Physical device
  
Side note on testing:
Notifications seem to be bugged on the simulator, at least on mine. Should test on a *physical device*.
I was able to get my notifs to appear by setting them then reopening the app in the simulator.

## Screenshots / Demo (if UI or notification change)
<img width="413" height="795" alt="Screenshot 2026-04-05 at 3 48 05 PM" src="https://github.com/user-attachments/assets/ac616f3b-a83f-4436-9205-bb703d8dcd6b" />
Pic taken while dismissing the notification

## Checklist
- [x] Commit messages follow Conventional Commits
- [x] PR title follows `[type](scope): short description`
- [x] PR target branch is not `main` and is our current working update branch (e.g. `maizebus2.1`)
- [x] No `print()` / `debugPrint()` / `console.log()` left in production code
- [x] Secrets / keys not committed