### PR TITLE
Revert "Persistent Favorited Stops"

### DIFF
--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -104,8 +104,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   static LatLng startLatLng = _defaultCenter;
 
   Set<Polyline> _displayedPolylines = {};
-  Map<String, Marker> _displayedStopMarkers = {}; // maps from stopID to marker
-  Map<String, Marker> _displayedFavoriteStopMarkers = {};
+  Set<Marker> _displayedStopMarkers = {};
   Set<Marker> _displayedBusMarkers = {};
   // Journey overlays for search results
   Set<Polyline> _displayedJourneyPolylines = {};
@@ -121,7 +120,6 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   Marker? _searchLocationMarker;
   final Set<String> _selectedRoutes = <String>{};
   List<Map<String, String>> _availableRoutes = [];
-  Map<String, bool> _stopIsRide = {};
 
   // Custom marker icons
   BitmapDescriptor? _busIcon;
@@ -137,7 +135,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   // Memoization caches
   final Map<String, Polyline> _routePolylines = {};
-  final Map<String, Map<String, Marker>> _routeStopMarkers = {}; // maps from route to a map of stopID to marker
+  final Map<String, Set<Marker>> _routeStopMarkers = {};
   // Whether a journey search overlay is currently active (shows only journey path)
   bool _journeyOverlayActive = false;
   // maximum allowed distance (meters) from a stop to a candidate polyline point
@@ -781,59 +779,51 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         );
       }
       if (!_routeStopMarkers.containsKey(routeKey)) {
-        _routeStopMarkers[routeKey] = {};
-        for (final stop in r.stops) { // iterate through all stops in this route
-          final isFavorite = _favoriteStops.contains(stop.id);
-          
-          final marker = Marker(
-            markerId: MarkerId(
-              'stop_${stop.id}_${Object.hashAll(r.points)}',
-            ),
-            position: stop.location,
-            flat: true,
-            icon: isFavorite
-                ? (stop.isRide
-                      ? _favRideStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )
-                      : _favStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            ))
-                : (stop.isRide
-                      ? _rideStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )
-                      : _stopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )),
-            consumeTapEvents: true,
-            onTap: () {
-              try {
-                Haptics.vibrate(HapticsType.light);
-              } catch (e) {}
+        _routeStopMarkers[routeKey] = r.stops
+            .map(
+              (stop) => Marker(
+                markerId: MarkerId(
+                  'stop_${stop.id}_${Object.hashAll(r.points)}',
+                ),
+                position: stop.location,
+                flat: true,
+                icon: _favoriteStops.contains(stop.id)
+                    ? (stop.isRide
+                          ? _favRideStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )
+                          : _favStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                ))
+                    : (stop.isRide
+                          ? _rideStopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )
+                          : _stopIcon ??
+                                BitmapDescriptor.defaultMarkerWithHue(
+                                  BitmapDescriptor.hueAzure,
+                                )),
+                consumeTapEvents: true,
+                onTap: () {
+                  try {
+                    Haptics.vibrate(HapticsType.light);
+                  } catch (e) {}
 
-              _showStopSheet(
-                stop.id,
-                stop.name,
-                stop.location.latitude,
-                stop.location.longitude,
-              );
-            },
-            rotation: stop.rotation,
-            anchor: Offset(0.5, 0.5),
-          );
-          _routeStopMarkers[routeKey]?[stop.id] = marker;
-
-          // gets first marker of this stop and adds it to the favorited stop markers 
-          if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
-            _displayedFavoriteStopMarkers[stop.id] = marker;
-          }
-          _stopIsRide[stop.id] = stop.isRide;
-        }
+                  _showStopSheet(
+                    stop.id,
+                    stop.name,
+                    stop.location.latitude,
+                    stop.location.longitude,
+                  );
+                },
+                rotation: stop.rotation,
+                anchor: Offset(0.5, 0.5),
+              ),
+            )
+            .toSet();
       }
     }
   }
@@ -869,73 +859,45 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   // Update cached markers for a specific stop id to reflect favorite/unfavorite
   void _setStopFavorited(String stpid, bool favored) {
     // Update all routeStopMarkers entries that match this stop id
-    final isRide = _stopIsRide[stpid] ?? false;
     _routeStopMarkers.forEach((routeKey, markers) {
-      // if marker does not exist in this route, return
-      if (!markers.containsKey(stpid)) return;
-
-      final m = markers[stpid]!; // get old marker
-      final newMarker = Marker(
-        flat: true,
-        markerId: m.markerId,
-        position: m.position,
-        icon: favored
-                ? (isRide
-                      ? _favRideStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )
-                      : _favStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            ))
-                : (isRide
-                      ? _rideStopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )
-                      : _stopIcon ??
-                            BitmapDescriptor.defaultMarkerWithHue(
-                              BitmapDescriptor.hueAzure,
-                            )),
-        consumeTapEvents: m.consumeTapEvents,
-        onTap: m.onTap,
-        rotation: m.rotation,
-        anchor: m.anchor,
-      );
-
-      // gets first marker of this stop id and adds it to the favorited stop markers 
-      if (favored && !_displayedFavoriteStopMarkers.containsKey(stpid)) {
-        _displayedFavoriteStopMarkers[stpid] = newMarker;
-      }
-
-      markers[stpid] = newMarker; // set as new marker
+      final updated = markers.map((m) {
+        if (m.markerId.value.startsWith('stop_${stpid}_')) {
+          return Marker(
+            flat: true,
+            markerId: m.markerId,
+            position: m.position,
+            icon: favored
+                ? (_favStopIcon ??
+                      _stopIcon ??
+                      BitmapDescriptor.defaultMarkerWithHue(
+                        BitmapDescriptor.hueAzure,
+                      ))
+                : (_stopIcon ??
+                      BitmapDescriptor.defaultMarkerWithHue(
+                        BitmapDescriptor.hueAzure,
+                      )),
+            consumeTapEvents: m.consumeTapEvents,
+            onTap: m.onTap,
+            rotation: m.rotation,
+            anchor: m.anchor,
+          );
+        }
+        return m;
+      }).toSet();
+      _routeStopMarkers[routeKey] = updated;
     });
-
-    // remove favorite stop marker if not favored
-    if (!favored) {
-      _displayedFavoriteStopMarkers.remove(stpid);
-    }
 
     // If displayed, update displayed markers as well
     setState(() {
       // Rebuild displayed stop markers based on current selected routes
-      final selectedStopMarkers = <String, Marker>{};
+      final selectedStopMarkers = <Marker>{};
       for (final routeId in _selectedRoutes) {
         final routeVariants = _routePolylines.keys.where(
           (key) => key.startsWith('${routeId}_'),
         );
         for (final routeKey in routeVariants) {
           final stops = _routeStopMarkers[routeKey];
-          if (stops == null) continue;
-
-          // iterate through and add the stop markers
-          // if they are not already in the selected stop markesr
-          stops.forEach((key, value) {
-            if (!selectedStopMarkers.containsKey(key)) {
-              selectedStopMarkers[key] = value;
-            }
-          });
+          if (stops != null) selectedStopMarkers.addAll(stops);
         }
       }
       _displayedStopMarkers = selectedStopMarkers;
@@ -945,7 +907,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
 
   void _updateDisplayedRoutes() {
     final selectedPolylines = <Polyline>{};
-    final selectedStopMarkers = <String, Marker>{};
+    final selectedStopMarkers = <Marker>{};
 
     for (final routeId in _selectedRoutes) {
       // Find all variants of this route
@@ -957,13 +919,9 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         final polyline = _routePolylines[routeKey];
         if (polyline != null) selectedPolylines.add(polyline);
         final stops = _routeStopMarkers[routeKey];
-        if (stops == null) continue;
-          
-        stops.forEach((key, value) {
-          if (!selectedStopMarkers.containsKey(key)) {
-            selectedStopMarkers[key] = value;
-          }
-        });
+        if (stops != null) {
+          selectedStopMarkers.addAll(stops);
+        }
       }
     }
 
@@ -1060,8 +1018,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   }
 
   void _updateAllDisplayedMarkers() {
-    _allDisplayedStopMarkers = _displayedStopMarkers.values.toSet()
-        .union(_displayedFavoriteStopMarkers.values.toSet())
+    _allDisplayedStopMarkers = _displayedStopMarkers
         .union(_displayedBusMarkers)
         .union(_displayedJourneyMarkers)
         .union(_searchLocationMarker != null ? {_searchLocationMarker!} : {});
@@ -1130,8 +1087,6 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   void _refreshCachedStopMarkers() {
     // Clear cached stop markers so they'll be recreated with the new icons
     _routeStopMarkers.clear();
-    // also clear persistent favorited stop markers to be refreshed in _cacheRouteOverlays(..)
-    _displayedFavoriteStopMarkers.clear();
     // Re-cache all route overlays with the new icons
     _cacheRouteOverlays(
       Provider.of<BusProvider>(context, listen: false).routes,
@@ -1925,7 +1880,6 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
         return StopSheet(
           stopID: stopID,
           stopName: stopName,
-          isFavorite: _favoriteStops.contains(stopID),
           onFavorite: _addFavoriteStop,
           onUnFavorite: _removeFavoriteStop,
           showBusSheet: (busId) {
@@ -2187,8 +2141,7 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
                                           ? {_searchLocationMarker!}
                                           : {},
                                     )
-                                  : _displayedStopMarkers.values.toSet()
-                                        .union(_displayedFavoriteStopMarkers.values.toSet())
+                                  : _displayedStopMarkers
                                         .union(_displayedJourneyMarkers)
                                         .union(
                                           _searchLocationMarker != null

--- a/lib/services/bus_info_service.dart
+++ b/lib/services/bus_info_service.dart
@@ -32,7 +32,12 @@ Future<List<BusStopWithPrediction>> fetchNextBusStops(String busID) async {
 }
 
 // for bus stops
-Future<List<BusWithPrediction>> fetchStopData(String stopID) async {
+Future<(List<BusWithPrediction>, bool)> fetchStopData(String stopID) async {
+
+  final prefs = await SharedPreferences.getInstance();
+  final list = prefs.getStringList('favorite_stops') ?? <String>[];
+  bool toReturn = list.contains(stopID);
+
   Uri url;
 
   if (int.tryParse(stopID) != null) {
@@ -48,7 +53,7 @@ Future<List<BusWithPrediction>> fetchStopData(String stopID) async {
   if (response.statusCode == 200) {
     final Map<String, dynamic> data = json.decode(response.body);
     final List<dynamic> predictions = data['bustime-response']['prd'];
-    return predictions.map((json) => BusWithPrediction.fromJson(json)).toList();
+    return (predictions.map((json) => BusWithPrediction.fromJson(json)).toList(), toReturn);
   } else {
     throw Exception('Failed to load bus stops');
   }

--- a/lib/widgets/bus_sheet.dart
+++ b/lib/widgets/bus_sheet.dart
@@ -50,8 +50,8 @@ class _BusSheetState extends State<BusSheet> {
 
         showMaizebusOKDialog(
           contextIn: context,
-          title: "Uh Oh!",
-          content: "Unable to fetch bus data. Please check your internet connection and try again.",
+          title: const Text("Uh Oh!"),
+          content: const Text("Unable to fetch bus data. Please check your internet connection and try again."),
         );
       }); 
     } else { 

--- a/lib/widgets/mini_stop_sheet.dart
+++ b/lib/widgets/mini_stop_sheet.dart
@@ -40,7 +40,7 @@ class MiniStopSheet extends StatefulWidget {
 }
 
 class _MiniStopSheetState extends State<MiniStopSheet> {
-  late Future<List<BusWithPrediction>> loadedStopData;
+  late Future<(List<BusWithPrediction>, bool)> loadedStopData;
 
   @override
   void initState() {
@@ -64,7 +64,7 @@ class _MiniStopSheetState extends State<MiniStopSheet> {
           List<BusWithPrediction> arrivingBuses = [];
           
           if (snapshot.hasData){
-            arrivingBuses = snapshot.data!;
+            arrivingBuses = snapshot.data!.$1;
           }
           
           if (snapshot.hasData) {

--- a/lib/widgets/stop_sheet.dart
+++ b/lib/widgets/stop_sheet.dart
@@ -17,7 +17,6 @@ import 'upcoming_stops_widget.dart';
 class StopSheet extends StatefulWidget {
   final String stopID;
   final String stopName;
-  final bool isFavorite;
   final Future<void> Function(String, String) onFavorite;
   final Future<void> Function(String, String) onUnFavorite;
   final void Function() onGetDirections;
@@ -28,7 +27,6 @@ class StopSheet extends StatefulWidget {
     Key? key,
     required this.stopID,
     required this.stopName,
-    required this.isFavorite,
     required this.onFavorite,
     required this.onUnFavorite,
     required this.onGetDirections,
@@ -217,10 +215,10 @@ class ExpandableStopWidget extends StatefulWidget {
     required this.busProvider,
   });
 }
-  
+
 class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
-  late Future<List<BusWithPrediction>> loadedStopData;
-  late bool _isFavorite;
+  late Future<(List<BusWithPrediction>, bool)> loadedStopData;
+  bool? _isFavorited;
   Timer? _refreshTimer;
   bool _isInBackground = false;
 
@@ -233,7 +231,6 @@ class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     loadedStopData = fetchStopData(widget.stopID);
-    _isFavorite = widget.isFavorite;
     imageBusStop =
         (widget.stopID == "C250") ||
         (widget.stopID == "N406") ||
@@ -340,10 +337,13 @@ class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
             List<BusWithPrediction> arrivingBuses = [];
 
             if (snapshot.hasData) {
-              arrivingBuses = snapshot.data!;
+              arrivingBuses = snapshot.data!.$1;
               arrivingBuses.sort(
                 (lhs, rhs) => (int.tryParse(lhs.prediction) ?? 0).compareTo(int.tryParse(rhs.prediction) ?? 0)
               );
+              if (_isFavorited == null) {
+                _isFavorited = snapshot.data!.$2;
+              }
             }
 
             double initialSize = 0.9;
@@ -728,8 +728,11 @@ class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
                                             
                                       ElevatedButton(
                                         onPressed: () {
+                                          // Read the current state
+                                          final bool currentStatus = _isFavorited ?? false;
+                                            
                                           // Call the appropriate function
-                                          if (_isFavorite){
+                                          if (currentStatus){
                                             widget.onUnFavorite(widget.stopID, widget.stopName);
                                           } else {
                                             widget.onFavorite(widget.stopID, widget.stopName);
@@ -737,7 +740,7 @@ class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
                                             
                                           // Update the UI immediately
                                           setState(() {
-                                            _isFavorite = !_isFavorite;
+                                            _isFavorited = !currentStatus;
                                           });
                                         },
                                         style: ElevatedButton.styleFrom(
@@ -751,8 +754,8 @@ class _StopSheetState extends State<StopSheet> with WidgetsBindingObserver {
                                           elevation: 0
                                         ),
                                         child: Icon(
-                                          (_isFavorite ?? false)?  Icons.favorite : Icons.favorite_border, 
-                                          color: (_isFavorite ?? false)? Colors.red : getColor(context, ColorType.secondaryButtonText),
+                                          (_isFavorited ?? false)?  Icons.favorite : Icons.favorite_border, 
+                                          color: (_isFavorited ?? false)? Colors.red : getColor(context, ColorType.secondaryButtonText),
                                           size: 20,
                                         ), 
                                       ),


### PR DESCRIPTION
Reverts mbusdev/bluebus-flutter#78

Reverting to move favorite stops logic back into `stop_sheet.dart` instead of passing it in from `map_screen.dart`