### PR TITLE
Call floor plans

### DIFF
--- a/lib/floorplan_api.dart
+++ b/lib/floorplan_api.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'constants.dart';
+import 'models/building_floors.dart';
+
+class FloorPlanApi {
+  static const String baseUrl = BACKEND_URL;
+
+  static Future<List<BuildingFloors>> fetchFloorPlans() async {
+   final response = await http.get(Uri.parse('$baseUrl/graph?buildingId=dc&floor=1')); //need to modify for specific buildings/floors
+   if (response.statusCode != 200) throw Exception('Failed to load floor plans');
+   final data = jsonDecode(response.body) as Map<String, dynamic>;
+   final floorPlan = BuildingFloors.fromJson(data);
+   //could do print(floorPlan); to test
+   return [floorPlan];
+  }
+}

--- a/lib/models/building_floors.dart
+++ b/lib/models/building_floors.dart
@@ -1,0 +1,59 @@
+class BuildingFloors {
+  final String buildingId;
+  final List<int> floors;
+  final List<Node> nodes;
+  final List<Edge> edges;
+
+  BuildingFloors({required this.buildingId, required this.floors, required this.nodes, required this.edges});
+
+  factory BuildingFloors.fromJson(Map<String, dynamic> j) => BuildingFloors(
+    buildingId: j['buildingId'],
+    floors: [j['floor'] as int],
+    nodes: (j['nodes'] as List).map((e) => Node.fromJson(e)).toList(),
+    edges: (j['edges'] as List).map((e) => Edge.fromJson(e)).toList(),
+  );
+
+  @override
+  String toString() => 'BuildingFloors($buildingId, $floors, $nodes, $edges)';
+}
+
+class Node {
+  final String id;
+  final String name;
+  final int floor;
+  final String type;
+  final double x;
+  final double y;
+
+  Node({required this.id, required this.name, required this.floor, required this.type, required this.x, required this.y});
+
+  factory Node.fromJson(Map<String, dynamic> j) => Node(
+    id: j['id'],
+    name: j['name'],
+    floor: j['floor'],
+    type: j['type'],
+    x: (j['x'] as num).toDouble(),
+    y: (j['y'] as num).toDouble(),
+  );
+
+  @override
+  String toString() => 'Node($id, $type, "$name", ($x, $y))';
+}
+
+class Edge {
+  final String id;
+  final String from;
+  final String to;
+  final String type;
+  final double cost;
+
+  Edge({required this.id, required this.from, required this.to, required this.type, required this.cost});
+
+  factory Edge.fromJson(Map<String, dynamic> j) => Edge(
+    id: j['id'], from: j['from'], to: j['to'],
+    type: j['type'], cost: j['cost'],
+  );
+
+  @override
+  String toString() => 'Edge($id, $from, $to, $type, $cost)';
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -39,6 +39,7 @@ import 'package:geolocator/geolocator.dart';
 import '../constants.dart';
 import './settings.dart';
 //import 'dart:convert';
+import 'package:bluebus/floorplan_api.dart';
 
 final NEW_BUTTON_SHOW_TIME = DateTime.parse("2026-03-16 00:00:00Z");
 final NEW_BUTTON_HIDE_TIME = DateTime.parse("2026-03-24 00:00:00Z");
@@ -235,6 +236,8 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
   }
 
   Future<void> _loadAllData() async {
+    final plans = await FloorPlanApi.fetchFloorPlans();
+
     ThemeProvider theme = Provider.of<ThemeProvider>(context, listen: false);
     theme.onSystemThemeUpdate(context);
     await theme.loadTheme(); // load user theme data


### PR DESCRIPTION
Description:
Added floorplan_api.dart and building_floors.dart to handle the floor plan data from the backend (both are modeled from bluebus_api.dart and bus_route_line.dart), then modified _loadAllData() in map_screen.dart to call fetchFloorPlans() defined in floorplan_api.dart. (Related Issues?) Nothing is currently done with the floor plan data in frontend- only a call is made. Additionally, the way we get floor plan data for specific buildings and floors needs to be modified because the code is currently written only for the first floor of the Duderstadt, which is the only floor plan data we have at the moment.

Changes made: Flutter

Testing Done: iOS Simulator (files added don't prevent the app interface from breaking, but was not able to test if fetchFloorPlans() really works for any building or floor)
