### PR TITLE
[feat](ui) Added "ripple on tap" effect, markers optimization

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dart analyze *)"
+    ]
+  }
+}

--- a/lib/screens/map_screen.dart
+++ b/lib/screens/map_screen.dart
@@ -1198,9 +1198,11 @@ class _MaizeBusCoreState extends State<MaizeBusCore> {
     if (!_isProgrammaticCameraMove) {
       _userHasInteractedWithMap = true;
     }
-    setState(() {
-      _currentCameraPos = position;
-    });
+
+    // Note: Please avoid calling setState() inside _onCameraMove since Flutter has to rebuild the map each time and it causes stuttering. Thanks!
+    // setState(() {
+    //   _currentCameraPos = position;
+    // });
   }
 
   void _onCameraIdle() async {

--- a/lib/services/map_image_service.dart
+++ b/lib/services/map_image_service.dart
@@ -433,7 +433,7 @@ class MapImageService {
 
     try {
       if (!_stopIconsInitialized) {
-        debugPrint("Stop icons not initialized, loading...");
+        // debugPrint("Stop icons not initialized, loading...");
         await _loadStopIcons();
       }
 

--- a/lib/services/map_image_service.dart
+++ b/lib/services/map_image_service.dart
@@ -348,7 +348,7 @@ class MapImageService {
     return frame.image;
   }
 
-  static void drawRouteIconOntoCanvas(Canvas canvas, int x, int y, int width, int height, String routeId) {
+  static void drawRouteIconOntoCanvas(Canvas canvas, int x, int y, int width, int height, String routeId, bool isRide) {
     final paint = Paint()
       ..color = RouteColorService.getRouteColor(routeId)
       ..style = PaintingStyle.fill;
@@ -366,8 +366,18 @@ class MapImageService {
       textAlign: TextAlign.center,
       textDirection: TextDirection.ltr
     )..layout(minWidth: 0, maxWidth: width.toDouble());
-
-    canvas.drawCircle(Offset(x + width / 2, y + height / 2), width / 2, paint);
+    
+    if (isRide) {
+      double rideIconHeight = height.toDouble() * 0.75;
+      double marginTop = (height - rideIconHeight) / 2;
+      final rrect = RRect.fromRectAndRadius(
+        Rect.fromLTWH(x.toDouble(), y.toDouble() + marginTop, width.toDouble(), rideIconHeight), 
+        Radius.circular(rideIconHeight / 2),
+      );
+      canvas.drawRRect(rrect, paint);
+    } else {
+      canvas.drawCircle(Offset(x + width / 2, y + height / 2), width / 2, paint);
+    }
     textPainter.paint(canvas, Offset(x + width / 2 - (textPainter.width / 2), y + height / 2 - (textPainter.height / 2)));
     // textPainter.paint(canvas, Offset(0,0));
   }
@@ -470,7 +480,8 @@ class MapImageService {
         yDrawPos, // y
         ROW_ICON_SIZE.toInt(), // width
         ROW_ICON_SIZE.toInt(), // height
-        routeId);
+        routeId,
+        isRide);
 
       xDrawPos += ROW_ICON_SIZE.toInt() + FANCY_STOP_ICON_SMALLMARGIN;
     }

--- a/lib/services/map_layers/base_routes_layer.dart
+++ b/lib/services/map_layers/base_routes_layer.dart
@@ -86,7 +86,7 @@ class BaseRoutesLayer extends CompositeMapLayer {
       }
     }
 
-    debugPrint("Pre-generating fancy stop icons");
+    // debugPrint("Pre-generating fancy stop icons");
     for (MapEntry entry in stopIdToRouteIds.entries) {
       try {
         await MapImageService.getFancyStopIcon(
@@ -100,10 +100,6 @@ class BaseRoutesLayer extends CompositeMapLayer {
     }
 
     // TODO: Sort the routeIDs for each key? Do we need to do this or is it already sorted? (It might be already sorted since we're going through the same ordering of routes each time)
-
-    // stopIdToRouteId.entries.forEach((e) => {
-    //   debugPrint("Bus stop ${e.key} has service from ${e.value.join(", ")}")
-    // },);
 
     await reloadAllMarkers();
     reloadPolylines();
@@ -135,20 +131,13 @@ class BaseRoutesLayer extends CompositeMapLayer {
     
 
     viewportLocation = newPosition.target;
-    // debugPrint("Camera zoomed from ${oldPosition.zoom} to ${newPosition.zoom}");
+
     if (oldPosition.zoom < FANCY_ICONS_ZOOM_THRESHOLD && newPosition.zoom >= FANCY_ICONS_ZOOM_THRESHOLD) {
-      // debugPrint("******* ENABLING FANCY ICONS");
       displayFancyIcons = true;
-      // TODO: Add a _markerGeneration++ statement here
-      // await reloadAllMarkers();
-      // if (isVisible) onUpdate();
       reloadAllMarkersStaggered();
     } else if (oldPosition.zoom >= FANCY_ICONS_ZOOM_THRESHOLD && newPosition.zoom < FANCY_ICONS_ZOOM_THRESHOLD) {
-      // debugPrint("******* DISABLING FANCY ICONS");
       displayFancyIcons = false;
       reloadAllMarkersStaggered();
-      // await reloadAllMarkers();
-      // if (isVisible) onUpdate();
     }
   }
 
@@ -197,86 +186,10 @@ class BaseRoutesLayer extends CompositeMapLayer {
 
   }
 
-  // Future<void> reloadMarkersForRoutes(List<BusRouteLine> routes) async {
-  //   // Used to only reload markers for a given list of routes. Useful because the fancy icons take some time for Google Maps to process (replacing 100+ markers with custom icons all at once causes a lot of stuttering), so we only process 1-2 routes per frame to keep things smoother
-  //   for (final r in routes) { // used to be routesCache
-  //     if (!selectedRoutes.contains(r.routeId)) continue; // Skip deselected routes
-
-  //     // Create unique key for each route variant (content-based hash)
-  //     final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
-
-  //     // Use backend color if available, otherwise fallback to service
-  //     final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
-
-  //     // if (!markersCache.containsKey(routeKey)) {
-  //     //   // Prevent duplicate copies of the same stop on top of each other
-  //     //   markersCache[routeKey] = {};
-  //     for (final (_, stop) in r.stops) {
-  //       // iterate through all stops in this route
-  //       // TODO: Implement favorite stops
-  //       // final isFavorite = _favoriteStops.contains(stop.id);
-
-  //       if (_markerBuiltAtGeneration[stop.id] == _markerGeneration) {
-  //         continue; // This is a duplicate marker that has already been updated. Skip it
-  //       }
-  //       _markerBuiltAtGeneration[stop.id] = _markerGeneration;
-
-
-  //       // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
-  //       Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
-
-  //       final marker = Marker(
-  //         zIndexInt:
-  //             2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
-  //         markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
-  //         position: stop.location,
-  //         flat: true,
-  //         icon:
-  //             // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
-  //             (displayFancyIcons)
-  //               ? (
-  //                 await MapImageService.getFancyStopIcon(
-  //                   stop.id,
-  //                   favoriteStops.contains(stop.id),
-  //                   stop.isRide,
-  //                   stop.rotation,
-  //                   routesServed.toList()
-  //                 )
-  //               ) : (
-  //                 favoriteStops.contains(stop.id) // Used to be isFavorite
-  //                 ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
-  //                 : (stop.isRide ? _rideStopIcon : _stopIcon)
-  //             ),
-  //         consumeTapEvents: true,
-  //         onTap: () {
-  //           onStopClicked(stop);
-  //         },
-  //         rotation: displayFancyIcons ? 0.0 : stop.rotation,
-  //         anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
-  //       );
-
-  //       markersCache[stop.id] = marker;
-
-  //       // gets first marker of this stop and adds it to the favorited stop markers
-  //       // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
-  //       //   _displayedFavoriteStopMarkers[stop.id] = marker;
-  //       // }
-  //       // _stopIsRide[stop.id] = stop.isRide;
-  //     }
-  //   }
-
-  //   markers = markersCache.values.toSet(); // Update global markers list
-
-  // }
-
   Future<void> reloadPreprocessedMarkersSegment(int markersToReload) async {
 
     int stopIndex = stopsToReloadCursor + markersToReload;
-    debugPrint("Reloading markers #${stopsToReloadCursor} to #${stopsToReloadCursor + markersToReload} out of ${stopsToReload.length}");
 
-    // if (!markersCache.containsKey(routeKey)) {
-    //   // Prevent duplicate copies of the same stop on top of each other
-    //   markersCache[routeKey] = {};
     for (; stopsToReloadCursor < math.min(stopsToReload.length, stopIndex); stopsToReloadCursor++) {
 
 
@@ -324,179 +237,14 @@ class BaseRoutesLayer extends CompositeMapLayer {
   }
 
     
-
-  // }
-  
-
-  // Future<void> reloadMarkersForRoutes(List<BusRouteLine> routes) async {
-  //   // Used to only reload markers for a given list of routes. Useful because the fancy icons take some time for Google Maps to process (replacing 100+ markers with custom icons all at once causes a lot of stuttering), so we only process 1-2 routes per frame to keep things smoother
-  //   for (final r in routes) { // used to be routesCache
-  //     if (!selectedRoutes.contains(r.routeId)) continue; // Skip deselected routes
-
-  //     // Create unique key for each route variant (content-based hash)
-  //     final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
-
-  //     // Use backend color if available, otherwise fallback to service
-  //     final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
-
-  //     // if (!markersCache.containsKey(routeKey)) {
-  //     //   // Prevent duplicate copies of the same stop on top of each other
-  //     //   markersCache[routeKey] = {};
-  //     for (final (_, stop) in r.stops) {
-  //       // iterate through all stops in this route
-  //       // TODO: Implement favorite stops
-  //       // final isFavorite = _favoriteStops.contains(stop.id);
-
-  //       if (_markerBuiltAtGeneration[stop.id] == _markerGeneration) {
-  //         continue; // This is a duplicate marker that has already been updated. Skip it
-  //       }
-  //       _markerBuiltAtGeneration[stop.id] = _markerGeneration;
-
-
-  //       // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
-  //       Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
-
-  //       final marker = Marker(
-  //         zIndexInt:
-  //             2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
-  //         markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
-  //         position: stop.location,
-  //         flat: true,
-  //         icon:
-  //             // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
-  //             (displayFancyIcons)
-  //               ? (
-  //                 await MapImageService.getFancyStopIcon(
-  //                   stop.id,
-  //                   favoriteStops.contains(stop.id),
-  //                   stop.isRide,
-  //                   stop.rotation,
-  //                   routesServed.toList()
-  //                 )
-  //               ) : (
-  //                 favoriteStops.contains(stop.id) // Used to be isFavorite
-  //                 ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
-  //                 : (stop.isRide ? _rideStopIcon : _stopIcon)
-  //             ),
-  //         consumeTapEvents: true,
-  //         onTap: () {
-  //           onStopClicked(stop);
-  //         },
-  //         rotation: displayFancyIcons ? 0.0 : stop.rotation,
-  //         anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
-  //       );
-
-  //       markersCache[stop.id] = marker;
-
-  //       // gets first marker of this stop and adds it to the favorited stop markers
-  //       // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
-  //       //   _displayedFavoriteStopMarkers[stop.id] = marker;
-  //       // }
-  //       // _stopIsRide[stop.id] = stop.isRide;
-  //     }
-  //   }
-
-  //   markers = markersCache.values.toSet(); // Update global markers list
-
-  // }
-
   Future<void> reloadAllMarkers() async {
     try {
       markersCache.clear();
       _markerGeneration++;
 
-      // FUTURE TODO: Create these icons asynchronously and CACHE THEM so they don't block when we're trying to load them all. Make sure they display all available routes even if only a few are selected (so the cache doesn't become invalid when the user selects different routes)
-
-      
       preprocessStopsToReload(routesCache);
       await reloadPreprocessedMarkersSegment(stopsToReload.length); // Reload ALL the markers at once. This also updates the markers variable
 
-      // markers.clear();
-
-      // No need to do this anymore since reloadProcessedMarkersSegment already updates the markers set
-      // markers = markersCache.values.expand((Map<String, Marker> m) {
-      //   return m.values;
-      // }).toSet();
-
-
-      // await reloadMarkersForRoutes(routesCache); // Reload all the markers all at once
-      // TODO: Call reloadAllMarkersStaggered here?
-
-      // for (final r in routesCache) {
-      //   if (!selectedRoutes.contains(r.routeId))
-      //     continue; // Skip deselected routes
-      //   // Create unique key for each route variant (content-based hash)
-      //   final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
-      //   // Use backend color if available, otherwise fallback to service
-      //   final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
-
-      //   if (!markersCache.containsKey(routeKey)) {
-      //     // Prevent duplicate copies of the same stop on top of each other
-      //     markersCache[routeKey] = {};
-      //     for (final (idx, stop) in r.stops) {
-      //       // iterate through all stops in this route
-      //       // TODO: Implement favorite stops
-      //       // final isFavorite = _favoriteStops.contains(stop.id);
-
-
-      //       // TODO: ****** See why the duplicate cache isn't working in some cases!
-
-      //       // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
-      //       Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
-
-      //       final marker = Marker(
-      //         zIndexInt:
-      //             2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
-      //         markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
-      //         position: stop.location,
-      //         flat: true,
-      //         // icon: BitmapDescriptor.defaultMarker,
-      //         icon:
-      //             // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
-      //             // favoriteStops.contains(stop.id) // Used to be isFavorite
-      //             // ? (stop.isRide ? MapImageService.favRideStopIcon : MapImageService.favStopIcon)
-      //             // : (stop.isRide ? MapImageService.rideStopIcon : MapImageService. stopIcon),
-      //             (displayFancyIcons) ? await MapImageService.getFancyStopIcon(stop.id, stop.rotation, routesServed.toList()) : MapImageService.stopIcon,
-
-      //             // NEXT STEPS TODO:
-      //             // * Stagger the marker updates across frames, instead of trying to load them in all at once. Process maybe 50-100 markers at a time before waiting
-      //             // * Add support for favorited stops (add the favorite/nonfavorite flag as part of the cache key to make sure our cache won't give us an old icon by mistake')
-      //             // * See if I can fix the rotation bug? Some stops have strange rotation--see if there is an existing function to "smooth out" the rotation so that it follows the polyline
-      //             // * Make the TheRide stop numbers ovals instead of circles
-      //             // * Also sort the list of stops every time!
-      //             // * And figure out why I'm getting so many ErrorSummary errors
-      //             // We can also think about "snapping"/"binning" the rotation to e.g. 20-degree increments to make the cache a little smaller
-
-      //             // TODO: Maybe only generate fancy stop icons if we can confirm the Marker is within view?
-
-
-      //             // favoriteStops.contains(stop.id) // Used to be isFavorite
-      //             // ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
-      //             // : (stop.isRide ? _rideStopIcon : _stopIcon),
-      //         consumeTapEvents: true,
-      //         onTap: () {
-      //           onStopClicked(stop);
-      //         },
-      //         rotation: displayFancyIcons ? 0.0 : stop.rotation,
-      //         anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
-      //       );
-      //       // _routeStopMarkers[routeKey]?[stop.id] = marker;
-
-      //       markersCache[routeKey]?[stop.id] = marker;
-
-      //       // gets first marker of this stop and adds it to the favorited stop markers
-      //       // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
-      //       //   _displayedFavoriteStopMarkers[stop.id] = marker;
-      //       // }
-      //       // _stopIsRide[stop.id] = stop.isRide;
-      //     }
-      //   }
-      // }
-
-      // markers = {};
-      // markers = markersCache.values.expand((Map<String, Marker> m) {
-      //   return m.values;
-      // }).toSet();
     } catch (err) {
       debugPrint("Error: $err");
     }
@@ -520,18 +268,6 @@ class BaseRoutesLayer extends CompositeMapLayer {
       await Future.delayed(Duration(milliseconds: 200));
     }
     
-
-    // for (int i = 0; i < (routesCache.length / 3); i++) {
-    //   // debugPrint("Reloading markers (staggered) for route ${routesCache[i].routeId}");
-    //   // await reloadMarkersForRoutes([routesCache[i]]);
-    //   await reloadMarkersForRoutes(routesCache.sublist(i * 3, math.min((i + 1) * 3, routesCache.length)));
-    //   // if (isVisible) onUpdate();
-    //   if (isVisible) onUpdate();
-    //   await SchedulerBinding.instance.endOfFrame;
-    //   await Future.delayed(Duration(milliseconds: 200));
-      
-    // }
-
     if (isVisible) onUpdate();
 
   }
@@ -590,11 +326,6 @@ class BaseRoutesLayer extends CompositeMapLayer {
         await rootBundle.load('assets/favbusStopRide.png'),
       );
 
-      // Refresh markers with new icons
-      // TODO: See if we need this!
-      // if (mounted) {
-      //   _refreshAllMarkers();
-      // }
     } catch (e) {
       // Fallback to default markers if custom loading fails
       // These are now set as initial values

--- a/lib/services/map_layers/base_routes_layer.dart
+++ b/lib/services/map_layers/base_routes_layer.dart
@@ -11,6 +11,15 @@ import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 
 const double FANCY_ICONS_ZOOM_THRESHOLD = 17.55;
+const int STAGGERED_RELOAD_CHUNK_SIZE = 50; // Load this many markers at a time when doing staggered reloads
+
+class StopReloadEntry {
+  final BusStop stop;
+  final String routeKey;
+  final Color routeColor;
+
+  StopReloadEntry({required this.stop, required this.routeKey, required this.routeColor});
+}
 
 class BaseRoutesLayer extends CompositeMapLayer {
   @override
@@ -21,6 +30,10 @@ class BaseRoutesLayer extends CompositeMapLayer {
   Set<Marker> markers = {};
   @override
   Function() onUpdate = () {};
+  @override
+  Function(LatLng) showRipple = (LatLng location) {
+    debugPrint("Warning! showRipple called but no callback was registered");
+  };
   Function(BusStop) onStopClicked = (BusStop s) {
     debugPrint("Warning! onStopClicked called but no callback was registered");
   };
@@ -46,6 +59,8 @@ class BaseRoutesLayer extends CompositeMapLayer {
   BitmapDescriptor _favRideStopIcon = BitmapDescriptor.defaultMarkerWithHue(
     BitmapDescriptor.hueAzure,
   );
+
+  LatLng viewportLocation = LatLng(42.280427, -83.736522); // Default/dummy coordinates we expect to get overwritten as soon as the user pans the map
 
   // Map<String, Map<String, Marker>> markersCache = {};
 
@@ -117,16 +132,19 @@ class BaseRoutesLayer extends CompositeMapLayer {
 
   @override
   void onCameraMove(CameraPosition oldPosition, CameraPosition newPosition) async {
+    
+
+    viewportLocation = newPosition.target;
     // debugPrint("Camera zoomed from ${oldPosition.zoom} to ${newPosition.zoom}");
     if (oldPosition.zoom < FANCY_ICONS_ZOOM_THRESHOLD && newPosition.zoom >= FANCY_ICONS_ZOOM_THRESHOLD) {
-      debugPrint("******* ENABLING FANCY ICONS");
+      // debugPrint("******* ENABLING FANCY ICONS");
       displayFancyIcons = true;
       // TODO: Add a _markerGeneration++ statement here
       // await reloadAllMarkers();
       // if (isVisible) onUpdate();
       reloadAllMarkersStaggered();
     } else if (oldPosition.zoom >= FANCY_ICONS_ZOOM_THRESHOLD && newPosition.zoom < FANCY_ICONS_ZOOM_THRESHOLD) {
-      debugPrint("******* DISABLING FANCY ICONS");
+      // debugPrint("******* DISABLING FANCY ICONS");
       displayFancyIcons = false;
       reloadAllMarkersStaggered();
       // await reloadAllMarkers();
@@ -134,10 +152,28 @@ class BaseRoutesLayer extends CompositeMapLayer {
     }
   }
 
-  Future<void> reloadMarkersForRoutes(List<BusRouteLine> routes) async {
-    // Used to only reload markers for a given list of routes. Useful because the fancy icons take some time for Google Maps to process (replacing 100+ markers with custom icons all at once causes a lot of stuttering), so we only process 1-2 routes per frame to keep things smoother
+  double getSquaredDistanceBetween(LatLng a, LatLng b) {
+    double lat_delta = a.latitude - b.latitude;
+    double lon_delta = a.longitude - b.longitude;
+    return lat_delta * lat_delta + lon_delta * lon_delta; // a^2 + b^2: Pythagorean theorem, sans square root (to make the calculation a little faster)
+  }
+
+  
+
+  List<StopReloadEntry> stopsToReload = [];
+  int stopsToReloadCursor = 0;
+
+  void preprocessStopsToReload(List<BusRouteLine> routes) {
+    // Fills the stopsToReload List and sorts them by distance to the viewport
+    stopsToReload.clear();
+    stopsToReloadCursor = 0;
+
     for (final r in routes) { // used to be routesCache
       if (!selectedRoutes.contains(r.routeId)) continue; // Skip deselected routes
+
+
+
+      // TODO: VVV Save these two variables in some data structure somewhere, or maybe alongside the Stop in the stopsToReload 
 
       // Create unique key for each route variant (content-based hash)
       final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
@@ -145,66 +181,224 @@ class BaseRoutesLayer extends CompositeMapLayer {
       // Use backend color if available, otherwise fallback to service
       final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
 
-      // if (!markersCache.containsKey(routeKey)) {
-      //   // Prevent duplicate copies of the same stop on top of each other
-      //   markersCache[routeKey] = {};
-      for (final (idx, stop) in r.stops) {
+      for (final (_, stop) in r.stops) {
         // iterate through all stops in this route
-        // TODO: Implement favorite stops
-        // final isFavorite = _favoriteStops.contains(stop.id);
 
         if (_markerBuiltAtGeneration[stop.id] == _markerGeneration) {
           continue; // This is a duplicate marker that has already been updated. Skip it
         }
         _markerBuiltAtGeneration[stop.id] = _markerGeneration;
+        stopsToReload.add(StopReloadEntry(stop: stop, routeKey: routeKey, routeColor: routeColor));
 
-
-        // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
-        Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
-
-        final marker = Marker(
-          zIndexInt:
-              2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
-          markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
-          position: stop.location,
-          flat: true,
-          icon:
-              // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
-              (displayFancyIcons)
-                ? (
-                  await MapImageService.getFancyStopIcon(
-                    stop.id,
-                    favoriteStops.contains(stop.id),
-                    stop.isRide,
-                    stop.rotation,
-                    routesServed.toList()
-                  )
-                ) : (
-                  favoriteStops.contains(stop.id) // Used to be isFavorite
-                  ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
-                  : (stop.isRide ? _rideStopIcon : _stopIcon)
-              ),
-          consumeTapEvents: true,
-          onTap: () {
-            onStopClicked(stop);
-          },
-          rotation: displayFancyIcons ? 0.0 : stop.rotation,
-          anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
-        );
-
-        markersCache[stop.id] = marker;
-
-        // gets first marker of this stop and adds it to the favorited stop markers
-        // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
-        //   _displayedFavoriteStopMarkers[stop.id] = marker;
-        // }
-        // _stopIsRide[stop.id] = stop.isRide;
       }
     }
 
-    markers = markersCache.values.toSet(); // Update global markers list
+    stopsToReload.sort((a, b) => getSquaredDistanceBetween(a.stop.location, viewportLocation).compareTo(getSquaredDistanceBetween(b.stop.location, viewportLocation))); // Sort by distance to the viewport
 
   }
+
+  // Future<void> reloadMarkersForRoutes(List<BusRouteLine> routes) async {
+  //   // Used to only reload markers for a given list of routes. Useful because the fancy icons take some time for Google Maps to process (replacing 100+ markers with custom icons all at once causes a lot of stuttering), so we only process 1-2 routes per frame to keep things smoother
+  //   for (final r in routes) { // used to be routesCache
+  //     if (!selectedRoutes.contains(r.routeId)) continue; // Skip deselected routes
+
+  //     // Create unique key for each route variant (content-based hash)
+  //     final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
+
+  //     // Use backend color if available, otherwise fallback to service
+  //     final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
+
+  //     // if (!markersCache.containsKey(routeKey)) {
+  //     //   // Prevent duplicate copies of the same stop on top of each other
+  //     //   markersCache[routeKey] = {};
+  //     for (final (_, stop) in r.stops) {
+  //       // iterate through all stops in this route
+  //       // TODO: Implement favorite stops
+  //       // final isFavorite = _favoriteStops.contains(stop.id);
+
+  //       if (_markerBuiltAtGeneration[stop.id] == _markerGeneration) {
+  //         continue; // This is a duplicate marker that has already been updated. Skip it
+  //       }
+  //       _markerBuiltAtGeneration[stop.id] = _markerGeneration;
+
+
+  //       // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
+  //       Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
+
+  //       final marker = Marker(
+  //         zIndexInt:
+  //             2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
+  //         markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
+  //         position: stop.location,
+  //         flat: true,
+  //         icon:
+  //             // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
+  //             (displayFancyIcons)
+  //               ? (
+  //                 await MapImageService.getFancyStopIcon(
+  //                   stop.id,
+  //                   favoriteStops.contains(stop.id),
+  //                   stop.isRide,
+  //                   stop.rotation,
+  //                   routesServed.toList()
+  //                 )
+  //               ) : (
+  //                 favoriteStops.contains(stop.id) // Used to be isFavorite
+  //                 ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
+  //                 : (stop.isRide ? _rideStopIcon : _stopIcon)
+  //             ),
+  //         consumeTapEvents: true,
+  //         onTap: () {
+  //           onStopClicked(stop);
+  //         },
+  //         rotation: displayFancyIcons ? 0.0 : stop.rotation,
+  //         anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
+  //       );
+
+  //       markersCache[stop.id] = marker;
+
+  //       // gets first marker of this stop and adds it to the favorited stop markers
+  //       // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
+  //       //   _displayedFavoriteStopMarkers[stop.id] = marker;
+  //       // }
+  //       // _stopIsRide[stop.id] = stop.isRide;
+  //     }
+  //   }
+
+  //   markers = markersCache.values.toSet(); // Update global markers list
+
+  // }
+
+  Future<void> reloadPreprocessedMarkersSegment(int markersToReload) async {
+
+    int stopIndex = stopsToReloadCursor + markersToReload;
+    debugPrint("Reloading markers #${stopsToReloadCursor} to #${stopsToReloadCursor + markersToReload} out of ${stopsToReload.length}");
+
+    // if (!markersCache.containsKey(routeKey)) {
+    //   // Prevent duplicate copies of the same stop on top of each other
+    //   markersCache[routeKey] = {};
+    for (; stopsToReloadCursor < math.min(stopsToReload.length, stopIndex); stopsToReloadCursor++) {
+
+
+      // iterate through all stops in this route
+      StopReloadEntry entry = stopsToReload[stopsToReloadCursor];
+
+      // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
+      Set<String> routesServed = stopIdToRouteIds[entry.stop.id] ?? {};
+
+      final marker = Marker(
+        zIndexInt:
+            2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
+        markerId: MarkerId('stop_${entry.stop.id}_${entry.routeKey}'),
+        position: entry.stop.location,
+        flat: true,
+        icon:
+            // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
+            (displayFancyIcons)
+              ? (
+                await MapImageService.getFancyStopIcon(
+                  entry.stop.id,
+                  favoriteStops.contains(entry.stop.id),
+                  entry.stop.isRide,
+                  entry.stop.rotation,
+                  routesServed.toList()
+                )
+              ) : (
+                favoriteStops.contains(entry.stop.id) // Used to be isFavorite
+                ? (entry.stop.isRide ? _favRideStopIcon : _favStopIcon)
+                : (entry.stop.isRide ? _rideStopIcon : _stopIcon)
+            ),
+        consumeTapEvents: true,
+        onTap: () {
+          showRipple(entry.stop.location);
+          onStopClicked(entry.stop);
+        },
+        rotation: displayFancyIcons ? 0.0 : entry.stop.rotation,
+        anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
+      );
+
+      markersCache[entry.stop.id] = marker;
+
+    }
+    markers = markersCache.values.toSet(); // Update global markers list
+  }
+
+    
+
+  // }
+  
+
+  // Future<void> reloadMarkersForRoutes(List<BusRouteLine> routes) async {
+  //   // Used to only reload markers for a given list of routes. Useful because the fancy icons take some time for Google Maps to process (replacing 100+ markers with custom icons all at once causes a lot of stuttering), so we only process 1-2 routes per frame to keep things smoother
+  //   for (final r in routes) { // used to be routesCache
+  //     if (!selectedRoutes.contains(r.routeId)) continue; // Skip deselected routes
+
+  //     // Create unique key for each route variant (content-based hash)
+  //     final routeKey = '${r.routeId}_${Object.hashAll(r.points)}';
+
+  //     // Use backend color if available, otherwise fallback to service
+  //     final routeColor = r.color ?? RouteColorService.getRouteColor(r.routeId);
+
+  //     // if (!markersCache.containsKey(routeKey)) {
+  //     //   // Prevent duplicate copies of the same stop on top of each other
+  //     //   markersCache[routeKey] = {};
+  //     for (final (_, stop) in r.stops) {
+  //       // iterate through all stops in this route
+  //       // TODO: Implement favorite stops
+  //       // final isFavorite = _favoriteStops.contains(stop.id);
+
+  //       if (_markerBuiltAtGeneration[stop.id] == _markerGeneration) {
+  //         continue; // This is a duplicate marker that has already been updated. Skip it
+  //       }
+  //       _markerBuiltAtGeneration[stop.id] = _markerGeneration;
+
+
+  //       // List<String> routesServed = ["BB", "CS", "CN", "CSX"];
+  //       Set<String> routesServed = stopIdToRouteIds[stop.id] ?? {};
+
+  //       final marker = Marker(
+  //         zIndexInt:
+  //             2000, // Put bus stops on top of buses, since all bus Z-indexes are between 0 and 999
+  //         markerId: MarkerId('stop_${stop.id}_${Object.hashAll(r.points)}'),
+  //         position: stop.location,
+  //         flat: true,
+  //         icon:
+  //             // TODO: Reimplement this isRide/isNotRide/isFavorite/etc logic
+  //             (displayFancyIcons)
+  //               ? (
+  //                 await MapImageService.getFancyStopIcon(
+  //                   stop.id,
+  //                   favoriteStops.contains(stop.id),
+  //                   stop.isRide,
+  //                   stop.rotation,
+  //                   routesServed.toList()
+  //                 )
+  //               ) : (
+  //                 favoriteStops.contains(stop.id) // Used to be isFavorite
+  //                 ? (stop.isRide ? _favRideStopIcon : _favStopIcon)
+  //                 : (stop.isRide ? _rideStopIcon : _stopIcon)
+  //             ),
+  //         consumeTapEvents: true,
+  //         onTap: () {
+  //           onStopClicked(stop);
+  //         },
+  //         rotation: displayFancyIcons ? 0.0 : stop.rotation,
+  //         anchor: displayFancyIcons ? MapImageService.getFancyStopIconOffset() : Offset(0.5, 0.5),
+  //       );
+
+  //       markersCache[stop.id] = marker;
+
+  //       // gets first marker of this stop and adds it to the favorited stop markers
+  //       // if (isFavorite && !_displayedFavoriteStopMarkers.containsKey(stop.id)) {
+  //       //   _displayedFavoriteStopMarkers[stop.id] = marker;
+  //       // }
+  //       // _stopIsRide[stop.id] = stop.isRide;
+  //     }
+  //   }
+
+  //   markers = markersCache.values.toSet(); // Update global markers list
+
+  // }
 
   Future<void> reloadAllMarkers() async {
     try {
@@ -213,7 +407,20 @@ class BaseRoutesLayer extends CompositeMapLayer {
 
       // FUTURE TODO: Create these icons asynchronously and CACHE THEM so they don't block when we're trying to load them all. Make sure they display all available routes even if only a few are selected (so the cache doesn't become invalid when the user selects different routes)
 
-      await reloadMarkersForRoutes(routesCache); // Reload all the markers all at once
+      
+      preprocessStopsToReload(routesCache);
+      await reloadPreprocessedMarkersSegment(stopsToReload.length); // Reload ALL the markers at once. This also updates the markers variable
+
+      // markers.clear();
+
+      // No need to do this anymore since reloadProcessedMarkersSegment already updates the markers set
+      // markers = markersCache.values.expand((Map<String, Marker> m) {
+      //   return m.values;
+      // }).toSet();
+
+
+      // await reloadMarkersForRoutes(routesCache); // Reload all the markers all at once
+      // TODO: Call reloadAllMarkersStaggered here?
 
       // for (final r in routesCache) {
       //   if (!selectedRoutes.contains(r.routeId))
@@ -298,18 +505,32 @@ class BaseRoutesLayer extends CompositeMapLayer {
   Future<void> reloadAllMarkersStaggered() async {
     // Accomplishes the same function as reloadAllMarkers(), but for big marker changes (i.e. adding fancy stop icons) where reloading everything on one frame causes lots of stuttering. It spreads the work across several frames to reduce jank
     _markerGeneration++;
-    
 
-    for (int i = 0; i < (routesCache.length / 3); i++) {
-      // debugPrint("Reloading markers (staggered) for route ${routesCache[i].routeId}");
-      // await reloadMarkersForRoutes([routesCache[i]]);
-      await reloadMarkersForRoutes(routesCache.sublist(i * 3, math.min((i + 1) * 3, routesCache.length)));
-      // if (isVisible) onUpdate();
+    int initialMarkerGeneration = _markerGeneration;
+
+    preprocessStopsToReload(routesCache);
+
+    while (stopsToReloadCursor < stopsToReload.length) {
+
+      if (initialMarkerGeneration < _markerGeneration) break; // Race condition prevention--if _markerGeneration is newer, then some future call to reloadAllMarkersStaggered() is already happening and this one should stop
+
+      await reloadPreprocessedMarkersSegment(STAGGERED_RELOAD_CHUNK_SIZE);
       if (isVisible) onUpdate();
       await SchedulerBinding.instance.endOfFrame;
       await Future.delayed(Duration(milliseconds: 200));
-      
     }
+    
+
+    // for (int i = 0; i < (routesCache.length / 3); i++) {
+    //   // debugPrint("Reloading markers (staggered) for route ${routesCache[i].routeId}");
+    //   // await reloadMarkersForRoutes([routesCache[i]]);
+    //   await reloadMarkersForRoutes(routesCache.sublist(i * 3, math.min((i + 1) * 3, routesCache.length)));
+    //   // if (isVisible) onUpdate();
+    //   if (isVisible) onUpdate();
+    //   await SchedulerBinding.instance.endOfFrame;
+    //   await Future.delayed(Duration(milliseconds: 200));
+      
+    // }
 
     if (isVisible) onUpdate();
 
@@ -343,8 +564,14 @@ class BaseRoutesLayer extends CompositeMapLayer {
     polylines = polylinesCache.values.toSet();
   }
 
+  @override
   void setOnUpdate(Function() callback) {
     onUpdate = callback;
+  }
+
+  @override
+  void setShowRipple(Function(LatLng) callback) {
+    showRipple = callback;
   }
 
   Future<void> _loadCustomMarkers() async {

--- a/lib/services/map_layers/live_buses_layer.dart
+++ b/lib/services/map_layers/live_buses_layer.dart
@@ -46,13 +46,18 @@ class LiveBusesLayer extends CompositeMapLayer {
   };
 
   @override
+  Function(LatLng) showRipple = (LatLng location) {
+    debugPrint("Error: showRipple called but callback was not registered!");
+  };
+
+  @override
   Set<Polyline> polylines = {};
 
   bool isAnimating = false;
   late Animation<double> animation;
   int nextAnimationFrameTime = 0;
   int animationStartedTime = 0;
-  static const int FRAME_DURATION = 100; // Frame duration in ms for animations
+  static const int FRAME_DURATION = 200; // Frame duration in ms for animations
   static const int ANIMATION_DURATION =
       11000; //4000; // Animation duration in ms
 
@@ -71,6 +76,11 @@ class LiveBusesLayer extends CompositeMapLayer {
   @override
   void setOnUpdate(Function() callback) {
     onUpdate = callback;
+  }
+
+  @override
+  void setShowRipple(Function(LatLng) callback) {
+    showRipple = callback;
   }
 
   void initWithTickerProvider(TickerProvider tickerProviderIn) {
@@ -103,7 +113,11 @@ class LiveBusesLayer extends CompositeMapLayer {
       icon: icon,
       rotation: bus.heading,
       anchor: const Offset(0.5, 0.5),
-      onTap: () => onBusClicked(bus),
+      onTap: () {
+        debugPrint("****** ON TAP");
+        showRipple(bus.position);
+        onBusClicked(bus);
+      },
     );
   }
 
@@ -185,6 +199,7 @@ class LiveBusesLayer extends CompositeMapLayer {
             rotation: interpolatedHeading,
             anchor: const Offset(0.5, 0.5), // Center the icon on the position
             onTap: () {
+              showRipple(interpolatedPosition);
               try {
                 Haptics.vibrate(HapticsType.light);
               } catch (e) {}

--- a/lib/services/map_layers/live_buses_layer.dart
+++ b/lib/services/map_layers/live_buses_layer.dart
@@ -114,7 +114,6 @@ class LiveBusesLayer extends CompositeMapLayer {
       rotation: bus.heading,
       anchor: const Offset(0.5, 0.5),
       onTap: () {
-        debugPrint("****** ON TAP");
         showRipple(bus.position);
         onBusClicked(bus);
       },
@@ -298,7 +297,6 @@ class LiveBusesLayer extends CompositeMapLayer {
     controller?.forward();
     controller?.repeat();
 
-    debugPrint("***** Finished starting animation");
   }
 
   void reload() {

--- a/lib/services/map_layers/navigation_layer.dart
+++ b/lib/services/map_layers/navigation_layer.dart
@@ -28,7 +28,6 @@ class NavigationLayer extends CompositeMapLayer {
   void reload() {
     // reloadMarkers();
     // reloadPolylines();
-    debugPrint("**** RELOADING NAVIGATIONLAYER, we have ${markers.length} markers and ${polylines} polylines");
     if (isVisible) onUpdate();
   }
 

--- a/lib/services/navigation/navigation_manager.dart
+++ b/lib/services/navigation/navigation_manager.dart
@@ -976,8 +976,6 @@ class NavigationManager {
     this.stageList.clear();
 
     for (Leg leg in journey.legs) {
-      // if (leg.")
-      debugPrint("Adding ${leg.origin}->${leg.destination} leg");
       // TODO: Call initWithLeg(leg) constructor here if it's a Bus leg
 
       if (leg.mode == LegMode.walk) {

--- a/lib/utils/rebuild_watchdog.dart
+++ b/lib/utils/rebuild_watchdog.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/foundation.dart';
+
+// Call tick() at the top of a State's build() method. Warns in the console if build()
+// is firing in a rapid burst (many calls with < threshold between them), which usually
+// means a setState() is being triggered from a high-frequency callback (onCameraMove,
+// a position stream, an animation listener, etc) instead of only when something visible
+// actually changed.
+class RebuildWatchdog {
+  final String label;
+  final Duration threshold;
+  final int consecutiveTrigger;
+  DateTime? _lastBuild;
+  int _rapidCount = 0;
+
+  RebuildWatchdog(
+    this.label, {
+    this.threshold = const Duration(milliseconds: 20),
+    this.consecutiveTrigger = 5,
+  });
+
+  void tick() {
+    if (!kDebugMode) return;
+    final now = DateTime.now();
+    if (_lastBuild != null && now.difference(_lastBuild!) < threshold) {
+      _rapidCount++;
+      if (_rapidCount == consecutiveTrigger) {
+        debugPrint(
+          '\x1B[33m⚠️ [$label] build() fired $consecutiveTrigger+ times <${threshold.inMilliseconds}ms apart — '
+          'likely rebuilding every frame (causes low performance/stutter). Check for setState() in a high-frequency callback '
+          '(onCameraMove, animation listener, build loop, etc).\x1B[0m',
+        );
+      }
+    } else {
+      _rapidCount = 0; // reset once builds slow back down, so it can fire again on a future incident
+    }
+    _lastBuild = now;
+  }
+}

--- a/lib/widgets/composite_map_widget.dart
+++ b/lib/widgets/composite_map_widget.dart
@@ -1,6 +1,7 @@
 import 'package:bluebus/constants.dart';
 import 'package:bluebus/services/map_layers/journey_layer.dart';
 import 'package:bluebus/services/map_layers/live_buses_layer.dart';
+import 'package:bluebus/utils/rebuild_watchdog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
@@ -13,6 +14,9 @@ abstract class CompositeMapLayer {
   Set<Marker> get markers;
   Function() get onUpdate;
   void setOnUpdate(Function() fn);
+  void setShowRipple(Function(LatLng) fn) {
+    debugPrint("Warning: setShowRipple called but method was not overridden.");
+  }
   void dispose() {}
 
   // Optional: If they need, CompositeMapLayers can include these things
@@ -42,15 +46,109 @@ class CompositeMapWidget extends StatefulWidget {
   }
 }
 
+class _RippleWidget extends StatefulWidget {
+  final Offset center;
+  final VoidCallback onComplete;
+
+  const _RippleWidget({
+    super.key,
+    required this.center,
+    required this.onComplete
+  });
+
+  @override
+  State<_RippleWidget> createState() => _RippleWidgetState();
+}
+
+class _RippleWidgetState extends State<_RippleWidget> with SingleTickerProviderStateMixin {
+
+  late final AnimationController _controller;
+  late final Animation<double> _scale;
+  late final Animation<double> _opacity;
+
+  double _maxRadius = 32;
+  static const _duration = Duration(milliseconds: 350);
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: _duration
+    )..addStatusListener((status) {
+      if (status == AnimationStatus.completed) widget.onComplete();
+    })..forward();
+
+    _scale = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOut
+    );
+
+    _opacity = Tween<double>(begin: 0.7, end: 0.0)
+      .animate(CurvedAnimation(parent: _controller, curve: Curves.easeOut));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final radius = _maxRadius * _scale.value;
+        return Positioned(
+          left: widget.center.dx - radius,
+          top: widget.center.dy - radius,
+          width: radius * 2,
+          height: radius * 2,
+          child: Opacity(
+            opacity: _opacity.value,
+            child: const DecoratedBox(
+              decoration: BoxDecoration(shape: BoxShape.circle, color: Colors.black)
+            )
+          )
+        );
+      },
+    );
+    
+    
+    
+  }
+
+}
+
 class CompositeMapWidgetState extends State<CompositeMapWidget>
     with SingleTickerProviderStateMixin {
   GoogleMapController? _mapController;
   Set<Marker> allMarkers = {};
   Set<Polyline> allPolylines = {};
   CameraPosition? oldCameraPosition;
+  ValueNotifier<List<Offset>> _ripples = ValueNotifier([]);
+  final _rebuildWatchdog = RebuildWatchdog('CompositeMapWidget');
 
   void reloadMap() {
     setState(() {}); // Rebuild with updated markers
+  }
+  void showRipple(LatLng location) async {
+    if (_mapController == null) {
+      debugPrint("mapcontroller is null!!!!!!!!!");
+      return;
+    }
+    debugPrint("Showing ripple at $location");
+    ScreenCoordinate coord = await _mapController!.getScreenCoordinate(location);
+    debugPrint("Got screen coordinate of $coord");
+    if (!mounted) return;
+    final devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+    final offset = Offset(coord.x / devicePixelRatio, coord.y / devicePixelRatio);
+    _ripples.value = [..._ripples.value, offset];
+  }
+  void _removeRipple(Offset offset) {
+    _ripples.value = _ripples.value.where((r) => r != offset).toList();
   }
 
   // GoogleMaps styles
@@ -71,6 +169,7 @@ class CompositeMapWidgetState extends State<CompositeMapWidget>
     _loadMapStyles();
     widget.mapLayers.forEach((CompositeMapLayer layer) {
       layer.setOnUpdate(reloadMap);
+      layer.setShowRipple(showRipple);
       if (layer is LiveBusesLayer) {
         layer.initWithTickerProvider(this);
       }
@@ -79,6 +178,7 @@ class CompositeMapWidgetState extends State<CompositeMapWidget>
 
   @override
   Widget build(BuildContext context) {
+    _rebuildWatchdog.tick();
     allMarkers = widget.mapLayers.expand<Marker>((CompositeMapLayer layer) {
       if (!layer.isVisible) return {};
       return layer.markers;
@@ -88,63 +188,87 @@ class CompositeMapWidgetState extends State<CompositeMapWidget>
       return layer.polylines;
     }).toSet();
 
-    return RepaintBoundary(
-      child: GoogleMap(
-        compassEnabled: false,
-        myLocationEnabled: true,
-        mapToolbarEnabled: false,
-        zoomControlsEnabled: false,
-        myLocationButtonEnabled: false,
-        markers: allMarkers,
-        polylines: allPolylines,
-        cameraTargetBounds: CameraTargetBounds(
-          LatLngBounds(
-            southwest: LatLng(
-              42.217530,
-              -83.84367266,
-            ), // Southern and Westernmost point
-            northeast: LatLng(
-              42.328602,
-              -83.53892646,
-            ), // Northern and Easternmost point
+    return Stack(
+      children: [
+        RepaintBoundary(
+          child: GoogleMap(
+            compassEnabled: false,
+            myLocationEnabled: true,
+            mapToolbarEnabled: false,
+            zoomControlsEnabled: false,
+            myLocationButtonEnabled: false,
+            markers: allMarkers,
+            polylines: allPolylines,
+            cameraTargetBounds: CameraTargetBounds(
+              LatLngBounds(
+                southwest: LatLng(
+                  42.217530,
+                  -83.84367266,
+                ), // Southern and Westernmost point
+                northeast: LatLng(
+                  42.328602,
+                  -83.53892646,
+                ), // Northern and Easternmost point
+              ),
+            ),
+            minMaxZoomPreference: const MinMaxZoomPreference(10, 21),
+            // markers: curMarkers.union(widget.staticMarkers),
+            initialCameraPosition: CameraPosition(
+              target: widget.initialCenter,
+              zoom: 15.0,
+            ),
+            style: isDarkMode(context) ? _darkMapStyle : _lightMapStyle,
+            onMapCreated: (GoogleMapController controller) {
+              _mapController = controller;
+              widget.mapLayers.forEach((CompositeMapLayer layer) {
+                if (layer is JourneyLayer) {
+                  layer.setMapController(controller);
+                }
+              });
+              widget.onMapCreated(controller);
+            },
+            onCameraMove: (CameraPosition position) {
+
+              if (oldCameraPosition == null) {
+                // First camera update
+                oldCameraPosition = position;
+
+              } else if (oldCameraPosition?.target != position.target ||
+                        oldCameraPosition?.tilt != position.tilt ||
+                        oldCameraPosition?.zoom != position.zoom) {
+                for (CompositeMapLayer layer in widget.mapLayers) {
+                  layer.onCameraMove(oldCameraPosition!, position);
+                }
+                oldCameraPosition = position;
+              }
+
+              widget.onCameraMove?.call(position);
+            },
+            onCameraIdle: widget.onCameraIdle,
           ),
         ),
-        minMaxZoomPreference: const MinMaxZoomPreference(10, 21),
-        // markers: curMarkers.union(widget.staticMarkers),
-        initialCameraPosition: CameraPosition(
-          target: widget.initialCenter,
-          zoom: 15.0,
-        ),
-        style: isDarkMode(context) ? _darkMapStyle : _lightMapStyle,
-        onMapCreated: (GoogleMapController controller) {
-          _mapController = controller;
-          widget.mapLayers.forEach((CompositeMapLayer layer) {
-            if (layer is JourneyLayer) {
-              layer.setMapController(controller);
-            }
-          });
-          widget.onMapCreated(controller);
-        },
-        onCameraMove: (CameraPosition position) {
 
-          if (oldCameraPosition == null) {
-            // First camera update
-            oldCameraPosition = position;
+        IgnorePointer(
+          child: ValueListenableBuilder<List<Offset>>(
+            valueListenable: _ripples,
+            builder: (context, ripples, _) {
+              return Stack(
+                children: ripples.map((offset) {
+                  return _RippleWidget(
+                    key: ObjectKey(offset),
+                    center: offset,
+                    onComplete: () => _removeRipple(offset)
 
-          } else if (oldCameraPosition?.target != position.target ||
-                     oldCameraPosition?.tilt != position.tilt ||
-                     oldCameraPosition?.zoom != position.zoom) {
-            for (CompositeMapLayer layer in widget.mapLayers) {
-              layer.onCameraMove(oldCameraPosition!, position);
-            }
-            oldCameraPosition = position;
-          }
-
-          widget.onCameraMove?.call(position);
-        },
-        onCameraIdle: widget.onCameraIdle,
-      ),
+                  );
+                }).toList()
+              );
+            },
+          ),
+        )
+      ],
     );
+    
+    
   }
 
   @override

--- a/lib/widgets/navigation_overlay_widget.dart
+++ b/lib/widgets/navigation_overlay_widget.dart
@@ -33,14 +33,11 @@ class _NavigationOverlayState extends State<NavigationOverlay>
   TimelineInfo timelineInfo = TimelineInfo();
 
   void updateTimeline() { // Call this after all the stages are loaded (or stages change)
-    // debugPrint("***** Updating timeline!");
     timelineInfo = widget.navigationManager.getTimeline();
-    // debugPrint("***** Timeline now has ${timelineSteps.length} things!");
   }
 
   @override
   void initState() {
-    // debugPrint("HELLO YELLO WE ARE IN IN/ITSTATE");
     super.initState();
     updateTimeline();
     widget.navigationManager.registerOverlay(this); // does not set to null, see the navigation manager


### PR DESCRIPTION
## Description

A new "Ripple on tap" effect when you click on a bus or bus stop on the map, as well as performance improvements to fancy marker reloading.

## Type of Change
- [x] New feature (`feat`)
- [ ] Bug fix (`fix`)
- [x] Refactor / code improvement
- [ ] Dependency / build update
- [ ] Documentation
- [ ] Other (explain)

## Related Issues

## Changes Made
- Flutter:
  - New `_RippleWidget`
  - `List<Offset> _ripples` list of locations to show ripples at
  - `setShowRipple(...)` function enabling a layer to tell `NavigationManager` to show a ripple
  - Small additions to `BaseRoutesLayer` and `LiveBusesLayer` to accept a `setShowRipple(...)` call and show ripples when buses or stops are tapped on
  - Replaced `reloadMarkersForRoutes` with two phases: `preprocessStopsToReload` and `reloadPreprocessedMarkersSegment(n)` to allow markers to be loaded in batches of ~50 sorted by distance to the viewport. (This prevents map stuttering by loading the closest markers first and then deferring the rest to future frames)
  - Tracks `viewportLocation` from `onCameraMove`
  - Fixed a bug in map_screen.dart where `setState()` was being called on every frame as the map was being panned
  - Added rebuild_watchdog.dart to log a warning if the map appears to be rebuilding on every frame
  - Added ride icon support in fancy icons (`drawRouteIconOntoCanvas`)
  - Increased animation duration in `live_buses_layer.dart` from 100ms to 200ms


## Testing Done
**Flutter:**
- [ ] Tested on:
  - [ ] iOS Simulator
  - [x] Android Emulator
  - [ ] Physical device

## Screenshots / Demo (if UI or notification change)
https://github.com/user-attachments/assets/2fe32ebe-ce43-48ad-8f8d-ee93999c6344

## Checklist
- [x] Commit messages follow Conventional Commits
- [x] PR title follows `[type](scope): short description`
- [x] PR target branch is not `main` and is our current working update branch (e.g. `maizebus2.1`)
- [x] No `print()` / `debugPrint()` / `console.log()` left in production code
- [x] Secrets / keys not committed
